### PR TITLE
static-stack2nix-builder: Don't assume mktemp is from coreutils.

### DIFF
--- a/static-stack2nix-builder-example/default.nix
+++ b/static-stack2nix-builder-example/default.nix
@@ -12,7 +12,7 @@ let
   pkgs = import (fetchTarball https://github.com/nh2/nixpkgs/archive/a2d7e9b875e8ba7fd15b989cf2d80be4e183dc72.tar.gz) {};
 
   # Pin static-haskell-nix version.
-  static-haskell-nix = fetchTarball https://github.com/nh2/static-haskell-nix/archive/de8346b794031a8104840e2e17193a15e26174a0.tar.gz;
+  static-haskell-nix = fetchTarball https://github.com/nh2/static-haskell-nix/archive/11f343f175be00a21d8b15063ec083b1fac0d79c.tar.gz;
 
   stack2nix-script = import "${static-haskell-nix}/static-stack2nix-builder/stack2nix-script.nix" {
     inherit pkgs;

--- a/static-stack2nix-builder/stack2nix-script.nix
+++ b/static-stack2nix-builder/stack2nix-script.nix
@@ -22,12 +22,18 @@
   # script prints only the final store path to stdout.
   # The output is generated to a `mktemp --directory` so that parallel
   # invocations don't influence each other.
+  # Note in this script we should qualify all executables from nix packages,
+  # as it's run in the user's shell (not in a normal nix build environment,
+  # since `stack2nix` needs internet access), so we can't make any assumptions
+  # about shell builtins or what's on PATH. For example, if `mktemp` is from
+  # `busybox` instead of `coreutils`, it may not support the `--directory`
+  # option.
   pkgs.writeScript "stack2nix-build-script.sh" ''
     #!/usr/bin/env bash
     set -eu -o pipefail
     export NIX_PATH=nixpkgs=${pkgs.path}
     export PATH=${pkgs.cabal-install}/bin:${pkgs.nix}/bin:$PATH
-    OUT_DIR=$(mktemp --directory -t stack2nix-output-dir.XXXXXXXXXX)
+    OUT_DIR=$(${pkgs.coreutils}/bin/mktemp --directory -t stack2nix-output-dir.XXXXXXXXXX)
     set -x
     ${pkgs.stack2nix}/bin/stack2nix "${stack-project-dir}" --hackage-snapshot "${hackageSnapshot}" -o "$OUT_DIR/stack2nix-output.nix" $@ 1>&2
     nix-store --add "$OUT_DIR/stack2nix-output.nix"

--- a/static-stack2nix-builder/stack2nix-script.nix
+++ b/static-stack2nix-builder/stack2nix-script.nix
@@ -22,18 +22,30 @@
   # script prints only the final store path to stdout.
   # The output is generated to a `mktemp --directory` so that parallel
   # invocations don't influence each other.
-  # Note in this script we should qualify all executables from nix packages,
+  # Note in this script we should qualify all executables from nix packages
+  # (or put them on PATH accordingly)
   # as it's run in the user's shell (not in a normal nix build environment,
   # since `stack2nix` needs internet access), so we can't make any assumptions
   # about shell builtins or what's on PATH. For example, if `mktemp` is from
   # `busybox` instead of `coreutils`, it may not support the `--directory`
   # option.
+  # And for example the `nixos/nix` Docker container is minimal and supplies
+  # many executables from `busybox`, such as `mktemp` and `wget`.
+  let
+    # Shell utils called by stack2nix or the script itself:
+    add_to_PATH = [
+      "${pkgs.coreutils}/bin" # `mktemp` et al
+      "${pkgs.cabal-install}/bin" # `cabal`
+      "${pkgs.nix}/bin" # various `nix-*` commands
+      "${pkgs.wget}/bin" # `wget`
+    ];
+  in
   pkgs.writeScript "stack2nix-build-script.sh" ''
     #!/usr/bin/env bash
     set -eu -o pipefail
     export NIX_PATH=nixpkgs=${pkgs.path}
-    export PATH=${pkgs.cabal-install}/bin:${pkgs.nix}/bin:$PATH
-    OUT_DIR=$(${pkgs.coreutils}/bin/mktemp --directory -t stack2nix-output-dir.XXXXXXXXXX)
+    export PATH=${pkgs.lib.concatStringsSep ":" add_to_PATH}:$PATH
+    OUT_DIR=$(mktemp --directory -t stack2nix-output-dir.XXXXXXXXXX)
     set -x
     ${pkgs.stack2nix}/bin/stack2nix "${stack-project-dir}" --hackage-snapshot "${hackageSnapshot}" -o "$OUT_DIR/stack2nix-output.nix" $@ 1>&2
     nix-store --add "$OUT_DIR/stack2nix-output.nix"


### PR DESCRIPTION
Fixes issue seen when used in `nixos/nix` docker image:

		building '/nix/store/ngsch8ridwjky8zvmdzl3j53sfw7831a-stack2nix-and-build-script.sh.drv'...
		mktemp: unrecognized option: directory
		BusyBox v1.29.3 (2019-01-24 07:45:07 UTC) multi-call binary.

		Usage: mktemp [-dt] [-p DIR] [TEMPLATE]

CC @mcgirr