### PR TITLE
Improvements to make geval build

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -13,4 +13,4 @@ if builtins.getEnv "STATIC_HASKELL_NIX_CI_NIXPKGS_UNSTABLE_BUILD" == "1"
     if builtins.pathExists ./nixpkgs/pkgs
       then import ./nixpkgs {}
       # Pinned nixpkgs version; should be kept up-to-date with our submodule.
-      else import (fetchTarball https://github.com/nh2/nixpkgs/archive/b577340eb5bc3b72549f0544b50e2e37df78bf12.tar.gz) {}
+      else import (fetchTarball https://github.com/nh2/nixpkgs/archive/d9cc01374235745ea8581174c4335ae9dda86504.tar.gz) {}

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -597,6 +597,7 @@ let
     };
 
     pixman = previous.pixman.overrideAttrs (old: { dontDisableStatic = true; });
+    freetype = previous.freetype.overrideAttrs (old: { dontDisableStatic = true; });
     fontconfig = previous.fontconfig.overrideAttrs (old: {
       dontDisableStatic = true;
       configureFlags = (old.configureFlags or []) ++ [
@@ -604,6 +605,9 @@ let
       ];
     });
     cairo = previous.cairo.overrideAttrs (old: { dontDisableStatic = true; });
+    libpng = previous.libpng.overrideAttrs (old: { dontDisableStatic = true; });
+    libpng_apng = previous.libpng_apng.overrideAttrs (old: { dontDisableStatic = true; });
+    libpng12 = previous.libpng12.overrideAttrs (old: { dontDisableStatic = true; });
 
     expat = previous.expat.overrideAttrs (old: { dontDisableStatic = true; });
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -565,7 +565,6 @@ let
     acl = issue_61682_throw "acl" previous.acl;
     attr = issue_61682_throw "attr" previous.attr;
     bash = issue_61682_throw "bash" previous.bash;
-    bzip2 = issue_61682_throw "bzip2" previous.bzip2;
     coreutils = issue_61682_throw "coreutils" previous.coreutils;
     diffutils = issue_61682_throw "diffutils" previous.diffutils;
     findutils = issue_61682_throw "findutils" previous.findutils;
@@ -577,7 +576,6 @@ let
     gnutar = issue_61682_throw "gnutar" previous.gnutar;
     gzip = issue_61682_throw "gzip" previous.gzip;
     patchelf = issue_61682_throw "patchelf" previous.patchelf;
-    pcre = issue_61682_throw "pcre" previous.pcre;
     xz = issue_61682_throw "xz" previous.xz;
     # For unknown reason we can't do this check on `zlib`, because if we do, we get:
     #
@@ -589,6 +587,10 @@ let
     # So somehow, the above `zlib_static` uses *this* `zlib`, even though
     # the above uses `previous.zlib.override` and thus shouldn't see this one.
     #zlib = issue_61682_throw "zlib" previous.zlib;
+    # Similarly, we don't know why these are are evaluated, but it happens for
+    # https://github.com/nh2/static-haskell-nix/issues/47.
+    #bzip2 = issue_61682_throw "bzip2" previous.bzip2;
+    #pcre = issue_61682_throw "pcre" previous.pcre;
 
     postgresql = (previous.postgresql.overrideAttrs (old: { dontDisableStatic = true; })).override {
       # We need libpq, which does not need systemd,


### PR DESCRIPTION
Should fix #47, and also make many other GUI programs easier to compile (note for #47 we still need manual linker overrides, but at least the `.a` files are available).

* Includes commit I've PR'd to nixpkgs: https://github.com/NixOS/nixpkgs/pull/66763