### PR TITLE
Update stack2nix to improve missing base packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,3 @@ The [`static-stack2nix-builder-example`](./static-stack2nix-builder-example) dir
 Another example of this is the the official static build of `stack` itself.
 See the [`static-stack`](./static-stack) directory for how that's done.
 `stack` is a big package with many dependencies, demonstrating that this works also for large projects.
-
-#### Note for Stackage `lts-14` users
-
-If you use `lts-14`, you may get errors like this (especially common for `text` and `stm`):
-
-```
-hash-stack2nix-output.nix called without required argument 'text'"
-```
-
-There is a simple workaround for it: Adding the same versions that are in the `resolver` version you use explicitly to `extra-deps`. Please see https://github.com/nh2/static-haskell-nix/issues/53#issuecomment-536355860 for an example.

--- a/static-stack2nix-builder/stack2nix-script.nix
+++ b/static-stack2nix-builder/stack2nix-script.nix
@@ -66,14 +66,16 @@
         # are faded out of current nixpkgs. Especially:
         #   * "Make sure output is written in UTF-8."
         #     https://github.com/input-output-hk/stack2nix/commit/cb05818ef8b58899f15641f50cb04e5473b4f9b0
+        #   * "Make GHC base libraries dependent on GHC version."
+        #     https://github.com/input-output-hk/stack2nix/pull/172/commits
         #
-        # Versions < 0.2.3 aren't supported, force-upgrade them to 0.2.3.
-        if stack2nix_pkgs.lib.versionOlder stack2nix_pkgs.stack2nix.version "0.2.3"
+        # Versions < 0.2.4 aren't supported, force-upgrade them to 0.2.4.
+        if stack2nix_pkgs.lib.versionOlder stack2nix_pkgs.stack2nix.version "0.2.4"
           then stack2nix_pkgs.haskellPackages.callCabal2nix "stack2nix" (stack2nix_pkgs.fetchFromGitHub {
-            owner = "input-output-hk";
+            owner = "nh2";
             repo = "stack2nix";
-            rev = "v0.2.3";
-            sha256 = "1b4g7800hvhr97cjssy5ffd097n2z0fvk9cm31a5jh66pkxys0mq";
+            rev = "c009e33af30c76b8fe94388382d816079fb5ac4e";
+            sha256 = "0x0hjzjlx1a0pyjd8aalk3ajwcymsb2qd65n2sqdhpy9bdsz8vxl";
           }) {}
           else stack2nix_pkgs.stack2nix;
   in


### PR DESCRIPTION
Fixes #53.

A common problem was that `text` and `stm` were missing for lts-14 builds.