### PR TITLE
Use bash from nix in scripts

### DIFF
--- a/static-stack/default.nix
+++ b/static-stack/default.nix
@@ -54,8 +54,7 @@ let
       });
 
   # Full invocation, including pinning `nix` version itself.
-  fullBuildScript = pkgs.writeScript "stack2nix-and-build-script.sh" ''
-    #!/usr/bin/env bash
+  fullBuildScript = pkgs.writeShellScript "stack2nix-and-build-script.sh" ''
     set -eu -o pipefail
     STACK2NIX_OUTPUT_PATH=$(${stack2nix-script})
     ${pkgs.nix}/bin/nix-build --no-link -A static_package --argstr stack2nix-output-path "$STACK2NIX_OUTPUT_PATH" "$@"

--- a/static-stack2nix-builder-example/default.nix
+++ b/static-stack2nix-builder-example/default.nix
@@ -34,8 +34,7 @@ let
   };
 
   # Full invocation, including pinning `nix` version itself.
-  fullBuildScript = pkgs.writeScript "stack2nix-and-build-script.sh" ''
-    #!/usr/bin/env bash
+  fullBuildScript = pkgs.writeShellScript "stack2nix-and-build-script.sh" ''
     set -eu -o pipefail
     STACK2NIX_OUTPUT_PATH=$(${stack2nix-script})
     export NIX_PATH=nixpkgs=${pkgs.path}

--- a/static-stack2nix-builder/stack2nix-script.nix
+++ b/static-stack2nix-builder/stack2nix-script.nix
@@ -79,8 +79,7 @@
           }) {}
           else stack2nix_pkgs.stack2nix;
   in
-  pkgs.writeScript "stack2nix-build-script.sh" ''
-    #!/usr/bin/env bash
+  pkgs.writeShellScript "stack2nix-build-script.sh" ''
     set -eu -o pipefail
     export NIX_PATH=nixpkgs=${pkgs.path}
     export PATH=${pkgs.lib.concatStringsSep ":" add_to_PATH}:$PATH


### PR DESCRIPTION
Shell scripts in `static-haskell-nix` depend on `#!/usr/bin/env bash` which doesn't necessarily come from nix (or may not even exist). Using `writeShellScript` looks like a safer alternative.
Discovered the issue and tested the fix by running inside the `nixos/nix` docker image which does not include bash by default.