### PR TITLE
survey: Fix returned haskellPackages not being overridable

### DIFF
--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1219,32 +1219,37 @@ let
 
   # Overlay all Haskell executables are statically linked.
   staticHaskellBinariesOverlay = final: previous: {
-    haskellPackages =
-      let
-          # We have to use `useFixedCabal` here, and cannot just rely on the
-          # "Cabal = ..." we override up in `haskellPackagesWithLibsReadyForStaticLinking`,
-          # because that `Cabal` isn't used in all packages:
-          # If a package doesn't explicitly depend on the `Cabal` package, then
-          # for compiling its `Setup.hs` the Cabal package that comes with GHC
-          # (that is in the default GHC package DB) is used instead, which
-          # obviously doesn' thave our patches.
-          statify = drv: with final.haskell.lib; final.lib.foldl appendConfigureFlag (disableLibraryProfiling (disableSharedExecutables (useFixedCabal drv))) ([
-            "--enable-executable-static" # requires `useFixedCabal`
-            "--extra-lib-dirs=${final.ncurses.override { enableStatic = true; }}/lib"
-          # TODO Figure out why this and the below libffi are necessary.
-          #      `working` and `workingStackageExecutables` don't seem to need that,
-          #      but `static-stack2nix-builder-example` does.
-          ] ++ final.lib.optionals (!integer-simple) [
-            "--extra-lib-dirs=${final.gmp6.override { withStatic = true; }}/lib"
-          ] ++ final.lib.optionals (!integer-simple && approach == "pkgsMusl") [
-            # GHC needs this if it itself wasn't already built against static libffi
-            # (which is the case in `pkgsStatic` only):
-            "--extra-lib-dirs=${final.libffi}/lib"
-          ]);
-      in
-        final.lib.mapAttrs (name: value:
-          if (isProperHaskellPackage value && isExecutable value) then statify value else value
-        ) previous.haskellPackages;
+    haskellPackages = previous.haskellPackages.override (old: {
+      overrides = final.lib.composeExtensions (old.overrides or (_: _: {})) (self: super:
+        let
+            # We have to use `useFixedCabal` here, and cannot just rely on the
+            # "Cabal = ..." we override up in `haskellPackagesWithLibsReadyForStaticLinking`,
+            # because that `Cabal` isn't used in all packages:
+            # If a package doesn't explicitly depend on the `Cabal` package, then
+            # for compiling its `Setup.hs` the Cabal package that comes with GHC
+            # (that is in the default GHC package DB) is used instead, which
+            # obviously doesn' thave our patches.
+            statify = drv: with final.haskell.lib; final.lib.foldl appendConfigureFlag (disableLibraryProfiling (disableSharedExecutables (useFixedCabal drv))) ([
+              "--enable-executable-static" # requires `useFixedCabal`
+              "--extra-lib-dirs=${final.ncurses.override { enableStatic = true; }}/lib"
+            # TODO Figure out why this and the below libffi are necessary.
+            #      `working` and `workingStackageExecutables` don't seem to need that,
+            #      but `static-stack2nix-builder-example` does.
+            ] ++ final.lib.optionals (!integer-simple) [
+              "--extra-lib-dirs=${final.gmp6.override { withStatic = true; }}/lib"
+            ] ++ final.lib.optionals (!integer-simple && approach == "pkgsMusl") [
+              # GHC needs this if it itself wasn't already built against static libffi
+              # (which is the case in `pkgsStatic` only):
+              "--extra-lib-dirs=${final.libffi}/lib"
+            ]);
+        in
+          final.lib.mapAttrs
+            (name: value:
+              if (isProperHaskellPackage value && isExecutable value) then statify value else value
+            )
+            super
+      );
+    });
   };
 
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -946,6 +946,11 @@ let
               # Test suite calls all kinds of shell unilities, can't work in sandbox.
               dotenv = dontCheck super.dotenv;
 
+              # Test suite fails time-dependently:
+              #     https://github.com/peti/cabal2spec/commit/6078778c06be45eb468f4770a3924c7be190f558
+              # TODO: Remove once a release > 2.4.1 is available to us.
+              cabal2spec = dontCheck super.cabal2spec;
+
               # Single test suite failure:
               #     set;get socket option (Pub):            FAIL
               #       *** Failed! Exception: 'ZMQError { errno = 22, source = "setByteStringOpt", message = "Invalid argument" }' (after 1 test):


### PR DESCRIPTION
So far, `staticHaskellBinariesOverlay` just did `mapAttrs` over `haskellPackages` directly.

That is wrong.

It should do a proper `haskellPackages.override`, just like `haskellLibsReadyForStaticLinkingOverlay` does, and so its `mapAttrs` over `super` instead.

This commit does that.

Because of this bug, it was until now impossible to further override the returned `haskellPackages`.
For example, using

    static_haskellPackages_with_fixes =
      static-stack2nix-builder.haskell-static-nix_output.haskellPackages.override (old: {
        # composeExtensions boilerplate here ...
         {
           # Haskell overrides here
         }
    });

(as is sometimes necessary for the `static-stack2nix-builder` to override one's own packages) would not work; as soon as `.override` was used, all packages inside would lose their static overrides, e.g. `configureFlags` would be reset to `""`.