### PR TITLE
nixpkgs: Patch to fix PyOpenSSL year 2020 test failures

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -13,4 +13,4 @@ if builtins.getEnv "STATIC_HASKELL_NIX_CI_NIXPKGS_UNSTABLE_BUILD" == "1"
     if builtins.pathExists ./nixpkgs/pkgs
       then import ./nixpkgs {}
       # Pinned nixpkgs version; should be kept up-to-date with our submodule.
-      else import (fetchTarball https://github.com/nh2/nixpkgs/archive/11aa987ea5b5a593c9ca7a38b391804959f905e5.tar.gz) {}
+      else import (fetchTarball https://github.com/nh2/nixpkgs/archive/6b43b1d11bb67607919256ea5b8a29aec770f1f7.tar.gz) {}

--- a/static-stack2nix-builder-example/default.nix
+++ b/static-stack2nix-builder-example/default.nix
@@ -13,7 +13,7 @@ let
     if builtins.pathExists ../.in-static-haskell-nix
       then toString ../. # for the case that we're in static-haskell-nix itself, so that CI always builds the latest version.
       # Update this hash to use a different `static-haskell-nix` version:
-      else fetchTarball https://github.com/nh2/static-haskell-nix/archive/61b2850e7aed78b9cba60cdb4f42d4bd0568d566.tar.gz;
+      else fetchTarball https://github.com/nh2/static-haskell-nix/archive/81006c805289116811650416a83f5689bed0209b.tar.gz;
 
   # Pin nixpkgs version
   # By default to the one `static-haskell-nix` provides, but you may also give


### PR DESCRIPTION
Should fix #75.

See https://github.com/NixOS/nixpkgs/issues/76879.