### PR TITLE
ci: Print version of nixpkgs unstable

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -2,7 +2,11 @@
 # We use that for scheduled builds tracking nixpkgs unstable on CI.
 # Of course that is NOT reproducible.
 if builtins.getEnv "STATIC_HASKELL_NIX_CI_NIXPKGS_UNSTABLE_BUILD" == "1"
-  then import (fetchTarball https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz) {}
+  then
+     let
+       nixpkgs = import (fetchTarball https://nixos.org/channels/nixpkgs-unstable/nixexprs.tar.xz) {};
+       msg = "Using version ${nixpkgs.lib.version} of nixpkgs-unstable channel.";
+     in builtins.trace msg nixpkgs
   else
     # If a `./nixpkgs` submodule exists, use that.
     # Note that this will take precedence over setting NIX_PATH!


### PR DESCRIPTION
Fixes #71.

Contributed by @cdepillabout.

Output looks like:

```
trace: Using version 20.03pre211021.690dd986b23 of nixpkgs-unstable channel.
```