### PR TITLE
nixpkgs: Update to latest unstable (2020-02-05)

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -17,4 +17,4 @@ if builtins.getEnv "STATIC_HASKELL_NIX_CI_NIXPKGS_UNSTABLE_BUILD" == "1"
     if builtins.pathExists ./nixpkgs/pkgs
       then import ./nixpkgs {}
       # Pinned nixpkgs version; should be kept up-to-date with our submodule.
-      else import (fetchTarball https://github.com/nh2/nixpkgs/archive/6b43b1d11bb67607919256ea5b8a29aec770f1f7.tar.gz) {}
+      else import (fetchTarball https://github.com/NixOS/nixpkgs/archive/0c960262d159d3a884dadc3d4e4b131557dad116.tar.gz) {}

--- a/static-stack2nix-builder-example/default.nix
+++ b/static-stack2nix-builder-example/default.nix
@@ -13,7 +13,7 @@ let
     if builtins.pathExists ../.in-static-haskell-nix
       then toString ../. # for the case that we're in static-haskell-nix itself, so that CI always builds the latest version.
       # Update this hash to use a different `static-haskell-nix` version:
-      else fetchTarball https://github.com/nh2/static-haskell-nix/archive/81006c805289116811650416a83f5689bed0209b.tar.gz;
+      else fetchTarball https://github.com/nh2/static-haskell-nix/archive/d1b20f35ec7d3761e59bd323bbe0cca23b3dfc82.tar.gz;
 
   # Pin nixpkgs version
   # By default to the one `static-haskell-nix` provides, but you may also give

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -21,6 +21,9 @@ in
   overlays ? [],
 
   approach ? # "pkgsMusl" or "pkgsStatic"
+    # TODO `pkgsStatic` support is currently not maintained and will likely be removed,
+    #      because `pkgsMusl` is a better base for what we need.
+    #      See https://github.com/NixOS/nixpkgs/issues/61575
     # TODO Find out why `pkgsStatic` creates ~3x larger binaries.
     "pkgsMusl", # does not exercise cross compilation
     # "pkgsStatic", # exercises cross compilation

--- a/update-example-commits.sh
+++ b/update-example-commits.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# Convenience script for the task of updating the git commits in the
+# example files.
+
+# Update file
+COMMIT="$(git rev-parse HEAD)"
+perl -pi -e "s:/static-haskell-nix/archive/........................................:/static-haskell-nix/archive/${COMMIT}:g" static-stack2nix-builder-example/default.nix
+
+# Commit
+git reset
+git add static-stack2nix-builder-example/default.nix
+git commit -m 'Update example commits'


### PR DESCRIPTION
Switches back to nixpkgs `master`, as all my patches have been incorporated upstream (see commit messages for exceptions).