### PR TITLE
ICU

### DIFF
--- a/survey/default.nix
+++ b/survey/default.nix
@@ -715,6 +715,10 @@ let
       # https://git.alpinelinux.org/aports/tree/community/R/APKBUILD?id=e2bce14c748aacb867713cb81a91fad6e8e7f7f6#n56
       doCheck = false;
     });
+
+    icu = previous.icu.overrideAttrs (old: {
+      configureFlags = old.configureFlags ++ ["--enable-static"];
+    });
   };
 
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1229,6 +1229,15 @@ let
                 dontCheck (overrideCabal super.hakyll (drv: {
                   testToolDepends = [];
                 }));
+
+              reflex-vty =
+                appendConfigureFlag (
+                  addStaticLinkerFlagsWithPkgconfig
+                  super.reflex-vty
+                  [ final.icu ]
+                  "--libs icu-uc"
+                ) "--ld-option=-Wl,--start-group --ld-option=-Wl,-lstdc++";
+
             });
 
         });


### PR DESCRIPTION
Static configure flag for icu, pulled in by text-icu.
Since I've been encountering this when trying to build a project with reflex-vty, I threw the fix for that in as well.

icu has multiple versions, with `icu` being an alias for `icu64` at the moment. Should there be an override for each of the other versions?