### PR TITLE
survey: Override ICU to have static libs

### DIFF
--- a/survey/default.nix
+++ b/survey/default.nix
@@ -661,6 +661,18 @@ let
     SDL2_image = previous.SDL2_image.overrideAttrs (old: { dontDisableStatic = true; });
     SDL2_mixer = previous.SDL2_mixer.overrideAttrs (old: { dontDisableStatic = true; });
 
+    # For icu, `dontDisableStatic` is not enough. We need explicit `--enable-static`.
+    # See https://github.com/unicode-org/icu/blob/0735ea8c6f6a0efa258db1f047edc63a43c6aafa/icu4c/source/configure.ac#L289-L299
+    # Also potentially concerning: http://userguide.icu-project.org/packaging
+    # > Users of your ICU must compile with -DU_STATIC_IMPLEMENTATION.
+    # TODO: Override ALL icu derivations, not just icu64.
+    icu64 = previous.icu64.overrideAttrs (old: {
+      dontDisableStatic = true;
+      configureFlags = (old.configureFlags or []) ++ [
+        "--enable-static"
+      ];
+    });
+
     libjpeg = previous.libjpeg.override (old: { enableStatic = true; });
     libjpeg_turbo = previous.libjpeg_turbo.override (old: { enableStatic = true; });
 


### PR DESCRIPTION
### TODO

* [ ] Potentially concerning: http://userguide.icu-project.org/packaging
  > Users of your ICU must compile with -DU_STATIC_IMPLEMENTATION.
  Does that really mean that all downstream projects have to pass `-DU_STATIC_IMPLEMENTATION` to their C preprocessor?
* [ ] Override ALL icu derivations, not just icu64.

CC @bgamari @angerman