### PR TITLE
Override callPackage to statify executables

### DIFF
--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1259,12 +1259,12 @@ let
               # (which is the case in `pkgsStatic` only):
               "--extra-lib-dirs=${final.libffi}/lib"
             ]);
+
+            statifyIfExecutable = drv: if isExecutable drv then statify drv else drv;
         in
-          final.lib.mapAttrs
-            (name: value:
-              if (isProperHaskellPackage value && isExecutable value) then statify value else value
-            )
-            super
+          {
+            callPackage = drv: args: statifyIfExecutable (super.callPackage drv args);
+          }
       );
     });
   };


### PR DESCRIPTION
This has the advantage of enabling us to just use `survey.haskellPackages.callPackage`, `callCabal2nix` and `developPackage` directly and have them generate static executables.

Note that this depends on  NixOS/nixpkgs#90271, so you don't want to merge this right now (hence the draft). So before merging we'd want to wait for that to be merged and update the pinned nixpkgs to some rev after that or backport the patch.