### PR TITLE
GHC 8.10 compatibility

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,11 +54,6 @@ steps:
 
       cd static-stack/
       mkdir -p static-stack-test-dir
-      curl -L https://github.com/commercialhaskell/stack/archive/v2.1.3.tar.gz | tar -xz -C static-stack-test-dir
-      # Use lts-12 because ghc822 is no longer in nixpkgs
-      cp static-stack-test-dir/stack-*/stack-lts-12.yaml static-stack-test-dir/stack-*/stack.yaml
-
-      echo "Overriding point release of unix-compat, see https://github.com/nh2/static-haskell-nix/issues/79"
-      perl -pi -e 's/^packages:/packages:\n- unix-compat-0.5.2\@rev:0/g' static-stack-test-dir/stack-*/snapshot-lts-12.yaml
+      curl -L https://github.com/commercialhaskell/stack/archive/v2.7.1.tar.gz | tar -xz -C static-stack-test-dir
 
       $(nix-build --no-link -A fullBuildScript --argstr stackDir $PWD/static-stack-test-dir/stack-*)

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,12 +48,4 @@ steps:
   # Stack via stack2nix
 
   - label: static-stack
-    # TODO: Remove the override of unix-compat below once that's available in stack
-    command: |
-      set -eu -o pipefail
-
-      cd static-stack/
-      mkdir -p static-stack-test-dir
-      curl -L https://github.com/commercialhaskell/stack/archive/v2.7.1.tar.gz | tar -xz -C static-stack-test-dir
-
-      $(nix-build --no-link -A fullBuildScript --argstr stackDir $PWD/static-stack-test-dir/stack-*)
+    command: "cd static-stack && ./build-static-stack.sh"

--- a/README.md
+++ b/README.md
@@ -116,5 +116,7 @@ The [`static-stack`](./static-stack) directory shows how Stack itself can be bui
     then `/nix/store/dax3wjbjfrcwj6r3mafxj5fx6wcg5zbp-stack-2.3.0.1` is your final output _store path_ whose `/bin` directory contains your static executable.
 * I get `stack2nix: user error (No such package mypackage-1.2.3 in the cabal database. Did you run cabal update?)`.
   * You most likely have to bump the date like `hackageSnapshot = "2019-05-08T00:00:00Z";` to a newer date (past the time that package-version was added to Hackage).
+* Can I build Stack projects with resolvers that are too old to be supported by Stack >= 2?
+  * No. For that you need need to use an old `static-haskell-nix` version: The one before [this PR](https://github.com/nh2/static-haskell-nix/pull/98) was merged.
 * I get some other error. Can I just file an issue and have you help me with it?
   * Yes. If possible (especially if your project is open source), please push some code so that your issue can be easily reproduced.

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -25,4 +25,4 @@ if builtins.getEnv "STATIC_HASKELL_NIX_CI_NIXPKGS_UNSTABLE_BUILD" == "1"
     if builtins.pathExists ./nixpkgs/pkgs
       then import ./nixpkgs {}
       # Pinned nixpkgs version; should be kept up-to-date with our submodule.
-      else import (fetchTarball https://github.com/NixOS/nixpkgs/archive/0c960262d159d3a884dadc3d4e4b131557dad116.tar.gz) {}
+      else import (fetchTarball https://github.com/nh2/nixpkgs/archive/8d536f36256d30d8fa47b24caafb1af6405889f3.tar.gz) {}

--- a/static-stack/README.md
+++ b/static-stack/README.md
@@ -18,16 +18,6 @@ If you get an error such as:
 
 then update the `hackageSnapshot` date  in `default.nix` to a date that includes the package and version.
 
-### Temporarily: Use `stack-lts-12.yaml`
-
-See #81: Stack's main `stack.yaml` uses GHC 8.2.2, which is no longer in recent `nixpkgs`.
-
-If you get an error mentioning `error: attribute 'ghc822' in selection path 'haskell.compiler.ghc822' not found`, then build stack the same way [as our CI does it](https://github.com/nh2/static-haskell-nix/blob/38ef5a4e00b5f6fb421014829320d85899483874/.buildkite/pipeline.yml#L50-L64).
-
-Alternatively you can use an older version of `static-haskell-nix` that pins an older version of `nixpkgs` that still has `ghc822`.
-
-This issue will likely go away very soon given that [stack is as-of-writing upgrading `stack.yaml` to a newer LTS](https://github.com/commercialhaskell/stack/pull/5162).
-
 ## Binary caches for faster building (optional)
 
 You can use the caches described in the [top-level README](../README.md#binary-caches-for-faster-building-optional) for faster building.

--- a/static-stack/build-static-stack.sh
+++ b/static-stack/build-static-stack.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+set -eu -o pipefail
+
+mkdir -p static-stack-test-dir
+curl -L https://github.com/commercialhaskell/stack/archive/v2.7.1.tar.gz | tar -xz -C static-stack-test-dir
+
+$(nix-build --no-link -A fullBuildScript --argstr stackDir $PWD/static-stack-test-dir/stack-*)

--- a/static-stack/default.nix
+++ b/static-stack/default.nix
@@ -9,14 +9,15 @@
 }:
 let
   cabalPackageName = "stack";
-  compiler = "ghc844"; # matching stack-lts-12.yaml
+  compiler = "ghc8104"; # matching stack-lts-12.yaml
 
   pkgs = import ../nixpkgs {};
 
   stack2nix-script = import ../static-stack2nix-builder/stack2nix-script.nix {
-    pkgs = pkgs;
+    inherit pkgs;
+    inherit compiler;
     stack-project-dir = stackDir; # where stack.yaml is
-    hackageSnapshot = "2020-02-08T00:00:00Z"; # pins e.g. extra-deps without hashes or revisions
+    hackageSnapshot = "2021-07-12T00:00:00Z"; # pins e.g. extra-deps without hashes or revisions
   };
 
   static-stack2nix-builder = import ../static-stack2nix-builder/default.nix {

--- a/static-stack2nix-builder-example/default.nix
+++ b/static-stack2nix-builder-example/default.nix
@@ -13,7 +13,7 @@ let
     if builtins.pathExists ../.in-static-haskell-nix
       then toString ../. # for the case that we're in static-haskell-nix itself, so that CI always builds the latest version.
       # Update this hash to use a different `static-haskell-nix` version:
-      else fetchTarball https://github.com/nh2/static-haskell-nix/archive/d1b20f35ec7d3761e59bd323bbe0cca23b3dfc82.tar.gz;
+      else fetchTarball https://github.com/nh2/static-haskell-nix/archive/39f2f38ed042e84d8b6627a236c1815f48023d3c.tar.gz;
 
   # Pin nixpkgs version
   # By default to the one `static-haskell-nix` provides, but you may also give

--- a/static-stack2nix-builder-example/default.nix
+++ b/static-stack2nix-builder-example/default.nix
@@ -6,7 +6,7 @@
 }:
 let
   cabalPackageName = "example-project";
-  compiler = "ghc865"; # matching stack.yaml
+  compiler = "ghc8104"; # matching stack.yaml
 
   # Pin static-haskell-nix version.
   static-haskell-nix =
@@ -23,8 +23,9 @@ let
 
   stack2nix-script = import "${static-haskell-nix}/static-stack2nix-builder/stack2nix-script.nix" {
     inherit pkgs;
+    inherit compiler;
     stack-project-dir = toString ./.; # where stack.yaml is
-    hackageSnapshot = "2019-10-08T00:00:00Z"; # pins e.g. extra-deps without hashes or revisions
+    hackageSnapshot = "2021-07-11T00:00:00Z"; # pins e.g. extra-deps without hashes or revisions
   };
 
   static-stack2nix-builder = import "${static-haskell-nix}/static-stack2nix-builder/default.nix" {

--- a/static-stack2nix-builder-example/stack.yaml
+++ b/static-stack2nix-builder-example/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-14.7
+resolver: lts-18.2
 packages:
 - .

--- a/static-stack2nix-builder/default.nix
+++ b/static-stack2nix-builder/default.nix
@@ -5,19 +5,19 @@
   # The name of the cabal package to build, e.g. "pandoc".
   cabalPackageName ? "myproject",
 
-  # Compiler name in nixpkgs, e.g. "ghc864".
+  # Compiler name in nixpkgs, e.g. "ghc8104".
   # Must match the one in the `resolver` in `stack.yaml`.
   # If you get this wrong, you'll likely get an error like
   #     <command line>: cannot satisfy -package-id Cabal-2.4.1.0-ALhzvdqe44A7vLWPOxSupv
   # TODO: Make `stack2nix` tell us that.
-  compiler ? "ghc864",
+  compiler ? "ghc8104",
 
   # Path to `stack2nix` output that shall be used as Haskell packages.
   # You should usually give this the store path that `stack2nix-script` outputs.
   stack2nix-output-path,
 
   # Pin nixpkgs version.
-  normalPkgs ? import (fetchTarball https://github.com/NixOS/nixpkgs/archive/88ae8f7d55efa457c95187011eb410d097108445.tar.gz) {},
+  normalPkgs ? import (fetchTarball https://github.com/nh2/nixpkgs/archive/8d536f36256d30d8fa47b24caafb1af6405889f3.tar.gz) {},
 
   # Use `integer-simple` instead of `integer-gmp` to avoid linking in
   # this LGPL dependency statically.

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -37,7 +37,10 @@ in
   # When changing this, also change the default version of Cabal declared below
   compiler ? "ghc8104",
 
-  # See https://www.haskell.org/cabal/download.html section "Older Releases".
+  # See:
+  # * https://www.snoyman.com/base/
+  # * https://www.haskell.org/cabal/download.html
+  #   section "Older Releases"
   defaultCabalPackageVersionComingWithGhc ?
     ({
       ghc822 = "Cabal_2_2_0_1"; # TODO this is technically incorrect for ghc 8.2.2, should be 2.0.1.0, but nixpkgs doesn't have that
@@ -47,6 +50,8 @@ in
       ghc865 = "Cabal_2_4_1_0"; # TODO this is technically incorrect for ghc 8.6.5, should be 2.4.0.1, but nixpkgs doesn't have that
       ghc881 = "Cabal_3_0_0_0";
       ghc8104 = "Cabal_3_2_1_0";
+      ghc8105 = "Cabal_3_2_1_0";
+      ghc901 = "Cabal_3_4_0_0";
     }."${compiler}"),
 
   # Use `integer-simple` instead of `integer-gmp` to avoid linking in

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1354,7 +1354,8 @@ let
             # obviously doesn' thave our patches.
             statify = drv: with final.haskell.lib; final.lib.foldl appendConfigureFlag (disableLibraryProfiling (disableSharedExecutables (useFixedCabal drv))) ([
               "--enable-executable-static" # requires `useFixedCabal`
-              "--extra-lib-dirs=${final.ncurses.override { enableStatic = true; }}/lib"
+              # `enableShared` seems to be required to avoid `recompile with -fPIC` errors on some packages.
+              "--extra-lib-dirs=${final.ncurses.override { enableStatic = true; enableShared = true; }}/lib"
             # TODO Figure out why this and the below libffi are necessary.
             #      `working` and `workingStackageExecutables` don't seem to need that,
             #      but `static-stack2nix-builder-example` does.

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1074,7 +1074,7 @@ let
               #     servant-server
               #   Some getting: *** abort because of serious configure-time warning from Cabal (multiple different package versions in project)
               #     stack2nix
-              Cabal =
+              Cabal = if !areCabalPatchesRequired then super.Cabal else # no patches needed -> don't even try to access any attributes
                 if approach == "pkgsMusl"
                   then ( # Example package where this matters: `focuslist`
                     # See note [When Cabal is `null` in a package set].

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1409,7 +1409,7 @@ in
         bench
         dhall
         hsyslog # Small example of handling https://github.com/NixOS/nixpkgs/issues/43849 correctly
-        aura
+        # aura # `aur` maked as broken in nixpkgs, but works here with `allowBroken = true;` actually
         ;
     } // (if approach == "pkgsStatic" then {} else {
       # Packages that work with `pkgsMusl` but fail with `pkgsStatic`:

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -908,6 +908,13 @@ let
                 # `ghc-options: -O2` in their .cabal file.
                 buildFlags = (attrs.buildFlags or []) ++
                   final.lib.optional disableOptimization "--ghc-option=-O0";
+
+                # There is currently a 300x `strip` performance regression in
+                # `binutils`, making some strips take 5 minutes instead of 1 second.
+                # Disable stripping until it's solved:
+                #     https://github.com/NixOS/nixpkgs/issues/129467
+                #     https://sourceware.org/bugzilla/show_bug.cgi?id=28058
+                dontStrip = true;
               });
 
               # Note:

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1000,6 +1000,11 @@ let
                 (if disableOptimization then dontCheck else lib.id)
                   super.aeson-diff;
 
+              # Tests use `inspection-testing` which cannot work on `-O0`.
+              ap-normalize =
+                (if disableOptimization then dontCheck else lib.id)
+                  super.ap-normalize;
+
               # `criterion`'s test suite fails with a timeout if its dependent
               # libraries (apparently `bytestring`) are compiled with `-O0`.
               # Even increasing the timeout 5x did not help!
@@ -1041,6 +1046,11 @@ let
               weigh =
                 (if disableOptimization then dontCheck else lib.id)
                   super.weigh;
+
+              # Tests use `inspection-testing` which cannot work on `-O0`.
+              generic-data =
+                (if disableOptimization then dontCheck else lib.id)
+                  super.generic-data;
 
               # `HsOpenSSL` has a bug where assertions are only triggered on `-O0`.
               # This breaks its test suite.
@@ -1169,6 +1179,11 @@ let
               # As of writing, not in Stackage.
               # Currently fails with linker error, see `yesod-paginator` below.
               erd = doJailbreak super.erd;
+
+              # Test timeout is too tight on `-O0`.
+              Glob =
+                (if disableOptimization then dontCheck else lib.id)
+                  super.Glob;
 
               # Tests fail with: doctests: <command line>: Dynamic loading not supported
               headroom = dontCheck super.headroom;
@@ -1444,6 +1459,12 @@ let
 
               # Test suite tries to run `minisat` which is not on PATH
               ersatz = dontCheck super.ersatz;
+
+              # Seems to time out on `-O0` (but does not print that timeout
+              # is the failure reason).
+              numeric-prelude =
+                (if disableOptimization then dontCheck else lib.id)
+                  super.numeric-prelude;
 
               # doctests test suite fails with:
               #     /build/trifecta-2.1/src/Text/Trifecta/Util/It.hs:61: failure in expression `let keepIt    a = Pure a'

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -970,12 +970,23 @@ let
                   # ])
                 ];
 
+                # Note [Slow stripping]:
                 # There is currently a 300x `strip` performance regression in
                 # `binutils`, making some strips take 5 minutes instead of 1 second.
-                # Disable stripping until it's solved:
+                # Disable stripping of libraries (`.a` files) until it's solved:
                 #     https://github.com/NixOS/nixpkgs/issues/129467
                 #     https://sourceware.org/bugzilla/show_bug.cgi?id=28058
-                dontStrip = true;
+                # We continue to strip executables because they don't seem to
+                # be affected by the regression.
+                #
+                # There is also the consideration to keep `dontStrip = true;` the default,
+                # so that people can decide at the very end whether they prefer small
+                # executable sizes, or increased debuggability by keeping debug symbols.
+                # However, until the `-g` issue
+                #     https://gitlab.haskell.org/ghc/ghc/-/issues/15960
+                # is figured out, it may be best to not enable `-g`, and thus
+                # not-stripping isn't as useful.
+                configureFlags = (attrs.configureFlags or []) ++ [ "--disable-library-stripping" ];
               });
 
               # Note:

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1228,6 +1228,11 @@ let
                 (if disableOptimization then dontCheck else lib.id)
                   super.text-short;
 
+              # Flaky QuickCheck test failure:
+              #     *** Failed! "00:01": expected Just 00:00:60, found Just 00:01:00 (after 95 tests and 2 shrinks):
+              # See https://github.com/haskellari/time-compat/issues/23
+              time-compat = dontCheck super.time-compat;
+
               # Added for #14
               tttool = callCabal2nix "tttool" (final.fetchFromGitHub {
                 owner = "entropia";

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1413,6 +1413,7 @@ in
         cabal-install
         bench
         dhall
+        dhall-json
         hsyslog # Small example of handling https://github.com/NixOS/nixpkgs/issues/43849 correctly
         # aura # `aur` maked as broken in nixpkgs, but works here with `allowBroken = true;` actually
         ;

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1247,7 +1247,7 @@ let
                   "--libs openssl";
               tmp-postgres =
                 addStaticLinkerFlagsWithPkgconfig
-                  super.tmp-postgres
+                  (dontCheck super.tmp-postgres) # flaky/stuck tests: https://github.com/jfischoff/tmp-postgres/issues/273
                   [ final.openssl ]
                   "--libs openssl";
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -144,12 +144,12 @@ let
     let
       stackageInfoPath = pkgs.path + "/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml";
       pythonWithYaml = pkgs.python2Packages.python.withPackages (pkgs: [pkgs.pyyaml]);
-      dont-distribute-packages-file = normalPkgs.runCommand "test" {} ''
+      stackage-packages-file = normalPkgs.runCommand "stackage-packages" {} ''
         ${pythonWithYaml}/bin/python -c 'import yaml, json; x = yaml.load(open("${stackageInfoPath}")); print(json.dumps([line.split(" ")[0] for line in x["default-package-overrides"]]))' > $out
       '';
-      dont-distribute-packages = builtins.fromJSON (builtins.readFile dont-distribute-packages-file);
+      stackage-packages = builtins.fromJSON (builtins.readFile stackage-packages-file);
     in
-      dont-distribute-packages;
+      stackage-packages;
 
   # Turns a list into a "set" (map where all values are {}).
   keySet = list: builtins.listToAttrs (map (name: lib.nameValuePair name {}) list);

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1217,6 +1217,17 @@ let
                   ])
                   "--libs nettle sdl2 SDL2_image xcursor libpng libjpeg libtiff-4 libwebp";
 
+              # With optimisations disabled, some tests of its test suite don't
+              # finish within the 25 seconds timeout.
+              skylighting-core =
+                (if disableOptimization then dontCheck else lib.id)
+                  super.skylighting-core;
+
+              # Test suite loops forever without optimisations..
+              text-short =
+                (if disableOptimization then dontCheck else lib.id)
+                  super.text-short;
+
               # Added for #14
               tttool = callCabal2nix "tttool" (final.fetchFromGitHub {
                 owner = "entropia";

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1340,6 +1340,22 @@ let
               #      but got: /nix/store/xz6sgnl68v00yhfk25cfankpdf7g57cs-binutils-2.31.1/bin/ld: warning: type and size of dynamic symbol `TextziTrifectaziDelta_zdfHasDeltaByteString_closure' are not defined
               trifecta = dontCheck super.trifecta;
 
+              # Test suite needs a missing dependency:
+              #     Configuring range-set-list-0.1.3.1...
+              #     ...
+              #     Setup: Encountered missing or private dependencies:
+              #     tasty >=0.8 && <1.4
+              range-set-list =
+                dontCheck (overrideCabal super.range-set-list { broken = false; });
+
+              # Test suite fails:
+              #
+              #     doctests:                                 FAIL
+              #       Exception: <command line>: Dynamic loading not supported
+              #     Parse a content-less file:                FAIL
+              #       Exception: test-files/trivial.proto: openFile: does not exist (No such file or directory)
+              #     2 out of 71 tests failed (1.97s)
+              proto3-suite = dontCheck super.proto3-suite;
             });
 
         });
@@ -1407,6 +1423,7 @@ in
         bench
         dhall
         dhall-json
+        proto3-suite
         hsyslog # Small example of handling https://github.com/NixOS/nixpkgs/issues/43849 correctly
         # aura # `aur` maked as broken in nixpkgs, but works here with `allowBroken = true;` actually
         ;

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -128,7 +128,7 @@ let
   # Contains a list of package names (strings).
   stackagePackages =
     let
-      stackageInfoPath = pkgs.path + "/pkgs/development/haskell-modules/configuration-hackage2nix.yaml";
+      stackageInfoPath = pkgs.path + "/pkgs/development/haskell-modules/configuration-hackage2nix/stackage.yaml";
       pythonWithYaml = pkgs.python2Packages.python.withPackages (pkgs: [pkgs.pyyaml]);
       dont-distribute-packages-file = normalPkgs.runCommand "test" {} ''
         ${pythonWithYaml}/bin/python -c 'import yaml, json; x = yaml.load(open("${stackageInfoPath}")); print(json.dumps([line.split(" ")[0] for line in x["default-package-overrides"]]))' > $out

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -927,6 +927,11 @@ let
               # see note [Packages that can't be overridden by overlays].
               zlib = super.zlib.override { zlib = final.zlib_both; };
 
+              # The `properties` test suite takes > 30 minutes with `-O0`.
+              aeson-diff =
+                (if disableOptimization then dontCheck else lib.id)
+                  super.aeson-diff;
+
               # `criterion`'s test suite fails with a timeout if its dependent
               # libraries (apparently `bytestring`) are compiled with `-O0`.
               # Even increasing the timeout 5x did not help!


### PR DESCRIPTION
In this PR we can collaborate to add GHC 8.10 compatibility as requested on #90.

For the general approach, see https://github.com/nh2/static-haskell-nix/issues/90#issuecomment-664551616.

## TODO

* [x] Wait for a Stackage LTS release that has GHC 8.10 because lots of packages simply declare bad upper bounds.
* [x] Upstream a musl ghc fix as described on https://github.com/nh2/static-haskell-nix/issues/99#issuecomment-665400600
  * PR: https://github.com/NixOS/nixpkgs/pull/129289
* [x] Fix remaining build errors
* [x] Ensure CI works
* [x] Ensure to bump the commits in the examples

## List of upstream PRs made as part of this

* `fontforge`: https://github.com/NixOS/nixpkgs/pull/94126
* `ilmbase`: https://github.com/NixOS/nixpkgs/pull/94205
  * https://github.com/AcademySoftwareFoundation/openexr/pull/798
* `mesa`: https://github.com/NixOS/nixpkgs/pull/94207
  * https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/6121