### PR TITLE
Bump to nixpkgs-21.11

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "nixpkgs"]
 	path = nixpkgs
-	url = https://github.com/nh2/nixpkgs.git
+	url = https://github.com/NixOS/nixpkgs.git

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 # Note: This is just a minimal example. For proper usage, see the README.
 
-{ nixpkgs ? (import ./nixpkgs.nix).pkgsMusl, compiler ? "ghc864", strip ? true }:
+{ nixpkgs ? (import ./nixpkgs.nix).pkgsMusl, compiler ? "ghc8107", strip ? true }:
 
 
 let
@@ -12,7 +12,7 @@ let
         pname = "example-scotty-app";
         version = "0.1.0.0";
         src = pkgs.lib.sourceByRegex ./. [
-          ".*\.cabal$"
+          ".*\\.cabal$"
           "^Setup.hs$"
           "^Main.hs$"
         ];
@@ -21,7 +21,7 @@ let
         enableSharedExecutables = false;
         enableSharedLibraries = false;
         executableHaskellDepends = [ base scotty ];
-        license = stdenv.lib.licenses.bsd3;
+        license = pkgs.lib.licenses.bsd3;
         configureFlags = [
           "--ghc-option=-optl=-static"
           "--extra-lib-dirs=${pkgs.gmp6.override { withStatic = true; }}/lib"
@@ -37,7 +37,6 @@ let
   haskellPackages = with pkgs.haskell.lib; normalHaskellPackages.override {
     overrides = self: super: {
       # Dependencies we need to patch
-      hpc-coveralls = appendPatch super.hpc-coveralls (builtins.fetchurl https://github.com/guillaume-nargeot/hpc-coveralls/pull/73/commits/344217f513b7adfb9037f73026f5d928be98d07f.patch);
     };
   };
 

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -25,4 +25,5 @@ if builtins.getEnv "STATIC_HASKELL_NIX_CI_NIXPKGS_UNSTABLE_BUILD" == "1"
     if builtins.pathExists ./nixpkgs/pkgs
       then import ./nixpkgs {}
       # Pinned nixpkgs version; should be kept up-to-date with our submodule.
-      else import (fetchTarball https://github.com/NixOS/nixpkgs/archive/d00b5a5fa6fe8bdf7005abb06c46ae0245aec8b5.tar.gz) {}
+      # This is nixos-21.11 as of 2021-12-15.
+      else import (fetchTarball https://github.com/NixOS/nixpkgs/archive/573095944e7c1d58d30fc679c81af63668b54056.tar.gz) {}

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -265,6 +265,17 @@ let
     # https://github.com/nh2/static-haskell-nix/issues/6#issuecomment-420494800
     "sparkle"
 
+    # PostgreSQL's test suite doesn't pass:
+    # https://github.com/NixOS/nixpkgs/issues/150930
+    #
+    # Even if the test suite is disabled, these Haskell binaries fail in
+    # linking with errors like:
+    #
+    # ld: libpq.a(fe-auth-scram.o): in function `pg_fe_scram_build_secret':
+    #   /build/postgresql-13.4/src/interfaces/libpq/fe-auth-scram.c:839:0: error:
+    #      undefined reference to `pg_saslprep'
+    "hasql-notifications" "hasql-queue" "postgresql-orm" "postgrest" "tmp-postgres"
+
     # These ones currently don't compile for not-yet-investigated reasons:
     "amqp-utils"
     "elynx"

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -28,6 +28,7 @@ in
   # * https://www.snoyman.com/base/
   # * https://www.haskell.org/cabal/download.html
   #   section "Older Releases"
+  # * https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history
   defaultCabalPackageVersionComingWithGhc ?
     ({
       ghc822 = "Cabal_2_2_0_1"; # TODO this is technically incorrect for ghc 8.2.2, should be 2.0.1.0, but nixpkgs doesn't have that
@@ -38,6 +39,7 @@ in
       ghc881 = "Cabal_3_0_0_0";
       ghc8104 = "Cabal_3_2_1_0";
       ghc8105 = "Cabal_3_2_1_0";
+      ghc8107 = "Cabal_3_2_1_0";
       ghc901 = "Cabal_3_4_0_0";
     }."${compiler}"),
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -265,17 +265,6 @@ let
     # https://github.com/nh2/static-haskell-nix/issues/6#issuecomment-420494800
     "sparkle"
 
-    # PostgreSQL's test suite doesn't pass:
-    # https://github.com/NixOS/nixpkgs/issues/150930
-    #
-    # Even if the test suite is disabled, these Haskell binaries fail in
-    # linking with errors like:
-    #
-    # ld: libpq.a(fe-auth-scram.o): in function `pg_fe_scram_build_secret':
-    #   /build/postgresql-13.4/src/interfaces/libpq/fe-auth-scram.c:839:0: error:
-    #      undefined reference to `pg_saslprep'
-    "hasql-notifications" "hasql-queue" "postgresql-orm" "postgrest" "tmp-postgres"
-
     # These ones currently don't compile for not-yet-investigated reasons:
     "amqp-utils"
     "elynx"
@@ -667,7 +656,12 @@ let
     #patchelf = issue_61682_throw "patchelf" previous.patchelf;
     #xz = issue_61682_throw "xz" previous.xz;
 
-    postgresql = (previous.postgresql.overrideAttrs (old: { dontDisableStatic = true; })).override {
+    # The test-suite for PostgreSQL 13 fails:
+    # https://github.com/NixOS/nixpkgs/issues/150930
+    #
+    # Even if you disable the test-suite, there are various linking issues.
+    # PostgreSQL 12 has similar issues, so we drop to PostgreSQL 11.
+    postgresql = (previous.postgresql_11.overrideAttrs (old: { dontDisableStatic = true; })).override {
       # We need libpq, which does not need systemd,
       # and systemd doesn't currently build with musl.
       enableSystemd = false;
@@ -1614,7 +1608,7 @@ in
         bench
         dhall
         dhall-json
-        # postgrest # postgresql's test fail
+        postgrest
         proto3-suite
         hsyslog # Small example of handling https://github.com/NixOS/nixpkgs/issues/43849 correctly
         # aura # `aur` maked as broken in nixpkgs, but works here with `allowBroken = true;` actually

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -507,6 +507,7 @@ let
       # `archiveFilesOverlay` below where `statify_curl_including_exe` is used.
       gssSupport = false;
       zlib = zlib_both;
+      brotliSupport = false;
     })).overrideAttrs (old: {
       dontDisableStatic = true;
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -765,6 +765,9 @@ let
     # so that `curl` can use it.
     curl = statify_curl_including_exe previous.curl final.zlib_both;
 
+    # curlMinimal also needs to be statified.
+    curlMinimal = statify_curl_including_exe previous.curlMinimal final.zlib_both;
+
     # `fetchurl` uses our overridden `curl` above, but `fetchurl` overrides
     # `zlib` in `curl`, see
     # https://github.com/NixOS/nixpkgs/blob/4a5c0e029ddbe89aa4eb4da7949219fe4e3f8472/pkgs/top-level/all-packages.nix#L296-L299

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1202,6 +1202,13 @@ let
               # Tests fail with: doctests: <command line>: Dynamic loading not supported
               headroom = dontCheck super.headroom;
 
+              # We need to explicitly get blas from openblasCompat, since
+              # otherwise openblas is used and Haskell programs like `resistor-cube`
+              # won't be able to find libblas.
+              blas-ffi = super.blas-ffi.override {
+                blas = final.openblasCompat;
+              };
+
               hmatrix =
                 # musl does not have `random_r()`.
                 (enableCabalFlag super.hmatrix "no-random_r")

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -734,7 +734,17 @@ let
     libjpeg = previous.libjpeg.override (old: { enableStatic = true; });
     libjpeg_turbo = previous.libjpeg_turbo.override (old: { enableStatic = true; });
 
-    openblas = previous.openblas.override { enableStatic = true; };
+    openblas = (previous.openblas.override { enableStatic = true; }).overrideAttrs (old: {
+      # openblas doesn't create symlinks for static archives like libblas.a and
+      # liblapack.a.  The following lines fixes this.
+      # https://github.com/NixOS/nixpkgs/pull/151049
+      postInstall = old.postInstall + ''
+        ln -s $out/lib/libopenblas.a $out/lib/libblas.a
+        ln -s $out/lib/libopenblas.a $out/lib/libcblas.a
+        ln -s $out/lib/libopenblas.a $out/lib/liblapack.a
+        ln -s $out/lib/libopenblas.a $out/lib/liblapacke.a
+      '';
+    });
 
     openssl = previous.openssl.override { static = true; };
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -859,6 +859,21 @@ let
       };
     };
 
+    # I'm not sure why this is needed.  As far as I can tell, libdevil doesn't
+    # directly link to libdeflate.  But libdevil does link to libtiff, which
+    # uses libdeflate.
+    #
+    # However, if libdevil doesn't have libdeflate as a buildInput, building
+    # libdevil fails with linking errors.
+    #
+    # I wasn't able to report this upstream, because in nixpkgs libdevil and
+    # pkgsMusl.libdevil build correctly.  Some transitive dependencies for
+    # pkgsStatic.libdevil fail to build, so it is hard to say whether this is a
+    # static-haskell-nix problem, or just a static-linking problem.
+    libdevil = previous.libdevil.overrideAttrs (oldAttrs: {
+      buildInputs = oldAttrs.buildInputs ++ [ final.libdeflate ];
+    });
+
   };
 
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1567,7 +1567,7 @@ in
         bench
         dhall
         dhall-json
-        postgrest
+        # postgrest # postgresql's test fail
         proto3-suite
         hsyslog # Small example of handling https://github.com/NixOS/nixpkgs/issues/43849 correctly
         # aura # `aur` maked as broken in nixpkgs, but works here with `allowBroken = true;` actually

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1647,6 +1647,7 @@ in
         "LambdaHack" # fails `systemd` dependency erroring on `#include <printf.h>`
         "language-puppet" # `base >=4.6 && <4.14, ghc-prim >=0.3 && <0.6` for dependency `protolude`
         "learn-physics" # needs opengl: `cannot find -lGLU` `-lGL`
+        "magico" # undefined reference to `_gfortran_concat_string'
         "odbc" # `odbcss.h: No such file or directory`
         "qchas" # `_gfortran_concat_string` linker error via openblas
         "rhine-gloss" # needs opengl: `cannot find -lGLU` `-lGL`

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -22,7 +22,7 @@ in
   ])."${approach}",
 
   # When changing this, also change the default version of Cabal declared below
-  compiler ? "ghc8104",
+  compiler ? "ghc8107",
 
   # See:
   # * https://www.snoyman.com/base/


### PR DESCRIPTION
This PR bumps to nixpkgs-21.11 (https://github.com/NixOS/nixpkgs/commit/573095944e7c1d58d30fc679c81af63668b54056), which contains LTS-18.17 and uses ghc-8.10.7.

This PR fixes or disables all the packages in `working` and `workingStackageExecutables`, so `ci.nix` should succeed.