### PR TITLE
Bump to recent-ish nixpkgs unstable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "nixpkgs"]
 	path = nixpkgs
-	url = https://github.com/nh2/nixpkgs.git
+	url = https://github.com/NixOS/nixpkgs.git

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 # Note: This is just a minimal example. For proper usage, see the README.
 
-{ nixpkgs ? (import ./nixpkgs.nix).pkgsMusl, compiler ? "ghc864", strip ? true }:
+{ nixpkgs ? (import ./nixpkgs.nix).pkgsMusl, compiler ? "ghc8104", strip ? true }:
 
 
 let
@@ -21,7 +21,7 @@ let
         enableSharedExecutables = false;
         enableSharedLibraries = false;
         executableHaskellDepends = [ base scotty ];
-        license = stdenv.lib.licenses.bsd3;
+        license = pkgs.lib.licenses.bsd3;
         configureFlags = [
           "--ghc-option=-optl=-static"
           "--extra-lib-dirs=${pkgs.gmp6.override { withStatic = true; }}/lib"

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 # Note: This is just a minimal example. For proper usage, see the README.
 
-{ nixpkgs ? (import ./nixpkgs.nix).pkgsMusl, compiler ? "ghc8104", strip ? true }:
+{ nixpkgs ? (import ./nixpkgs.nix).pkgsMusl, compiler ? "ghc8107", strip ? true }:
 
 
 let

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -25,4 +25,4 @@ if builtins.getEnv "STATIC_HASKELL_NIX_CI_NIXPKGS_UNSTABLE_BUILD" == "1"
     if builtins.pathExists ./nixpkgs/pkgs
       then import ./nixpkgs {}
       # Pinned nixpkgs version; should be kept up-to-date with our submodule.
-      else import (fetchTarball https://github.com/NixOS/nixpkgs/archive/d00b5a5fa6fe8bdf7005abb06c46ae0245aec8b5.tar.gz) {}
+      else import (fetchTarball https://github.com/NixOS/nixpkgs/archive/9a5aa75d56ad4163521f1692469e6dc54b90068c.tar.gz) {}

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -25,4 +25,4 @@ if builtins.getEnv "STATIC_HASKELL_NIX_CI_NIXPKGS_UNSTABLE_BUILD" == "1"
     if builtins.pathExists ./nixpkgs/pkgs
       then import ./nixpkgs {}
       # Pinned nixpkgs version; should be kept up-to-date with our submodule.
-      else import (fetchTarball https://github.com/NixOS/nixpkgs/archive/9a5aa75d56ad4163521f1692469e6dc54b90068c.tar.gz) {}
+      else import (fetchTarball https://github.com/NixOS/nixpkgs/archive/8eb14e7e79d6c34a9cce146182bfc8c820d527c2.tar.gz) {}

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -22,7 +22,7 @@ in
   ])."${approach}",
 
   # When changing this, also change the default version of Cabal declared below
-  compiler ? "ghc8104",
+  compiler ? "ghc8107",
 
   # See:
   # * https://www.snoyman.com/base/
@@ -38,6 +38,7 @@ in
       ghc881 = "Cabal_3_0_0_0";
       ghc8104 = "Cabal_3_2_1_0";
       ghc8105 = "Cabal_3_2_1_0";
+      ghc8107 = "Cabal_3_2_1_0";
       ghc901 = "Cabal_3_4_0_0";
     }."${compiler}"),
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1521,7 +1521,7 @@ let
                   [
                     "--enable-executable-static" # requires `useFixedCabal`
                     # `enableShared` seems to be required to avoid `recompile with -fPIC` errors on some packages.
-                    "--extra-lib-dirs=${final.ncurses.override { enableStatic = true; enableShared = true; }}/lib"
+                    "--extra-lib-dirs=${final.ncurses.override { enableStatic = true; }}/lib"
                   ]
                   # TODO Figure out why this and the below libffi are necessary.
                   #      `working` and `workingStackageExecutables` don't seem to need that,

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -81,6 +81,7 @@ let
   # `.override` and the likes).
   isProperHaskellPackage = val:
     lib.isDerivation val && # must pass lib.isDerivation
+    val.pname != "ghc-bignum" &&
     val ? env; # must have an .env key
 
   # Function that tells us if a given Haskell package has an executable.


### PR DESCRIPTION
This PR bumps nixpkgs to the version that's used for PostgREST's static-haskell-nix-based static build, and includes the patches to `survey.nix` used there.

Primary aim of the PR is to
- see whether static-haskell-nix CI is happy with that update
- share those `survey.nix` patches
