### PR TITLE
Create pkgsWithGhc package set

### DIFF
--- a/survey/default.nix
+++ b/survey/default.nix
@@ -574,56 +574,6 @@ let
       makeFlags = [ "curl_LDFLAGS=-all-static" ];
     });
 
-  fixGhc = ghcPackage0: lib.pipe ghcPackage0 [
-    # musl does not support libdw's alleged need for `dlopen()`, see:
-    #     https://github.com/nh2/static-haskell-nix/pull/116#issuecomment-1585786484
-    #
-    # Nixpkgs has the `enableDwarf` argument only for GHCs versions that are built
-    # with Hadrian (`common-hadrian.nix`), which in nixpkgs is the case for GHC >= 9.6.
-    # So set `enableDwarf = true`, but not for older versions known to not use Hadrian.
-    (ghcPackage:
-      if lib.any (prefix: lib.strings.hasPrefix prefix compiler) ["ghc8" "ghc90" "ghc92" "ghc94"]
-        then ghcPackage # GHC < 9.6, no Hadrian
-        else ghcPackage.override { enableDwarf = false; }
-    )
-    (ghcPackage:
-      ghcPackage.override {
-        enableRelocatedStaticLibs = useArchiveFilesForTemplateHaskell;
-        enableShared = !useArchiveFilesForTemplateHaskell;
-       }
-    )
-  ];
-
-  setupGhcOverlay = final: previous:
-    let
-      initialHaskellPackages =
-        if integer-simple
-          # Note we don't have to set the `-finteger-simple` flag for packages that GHC
-          # depends on (e.g. text), because nix + GHC already do this for us:
-          #   https://github.com/ghc/ghc/blob/ghc-8.4.3-release/ghc.mk#L620-L626
-          #   https://github.com/peterhoeg/nixpkgs/commit/50050f3cc9e006daa6800f15a29e258c6e6fa4b3#diff-2f6f8fd152c14d37ebd849aa6382257aR35
-          then previous.haskell.packages.integer-simple."${compiler}"
-          else previous.haskell.packages."${compiler}";
-    in
-      {
-        haskellPackages = initialHaskellPackages.override (old: {
-
-          # To override GHC, we need to override both `ghc` and the one in
-          # `buildHaskellPackages` because otherwise this code in `geneic-builder.nix`
-          # will make our package depend on 2 different GHCs:
-          #     nativeGhc = buildHaskellPackages.ghc;
-          #     depsBuildBuild = [ nativeGhc ] ...
-          #     nativeBuildInputs = [ ghc removeReferencesTo ] ...
-          #
-          ghc = fixGhc old.ghc;
-          buildHaskellPackages = old.buildHaskellPackages.override (oldBuildHaskellPackages: {
-            ghc = fixGhc oldBuildHaskellPackages.ghc;
-          });
-        });
-      };
-
-  pkgsWithGhc = pkgs.extend setupGhcOverlay;
-
   # Overlay that enables `.a` files for as many system packages as possible.
   # This is in *addition* to `.so` files.
   # See also https://github.com/NixOS/nixpkgs/issues/61575
@@ -914,9 +864,57 @@ let
 
   };
 
+  pkgsWithArchiveFiles = pkgs.extend archiveFilesOverlay;
 
-  pkgsWithArchiveFiles = pkgsWithGhc.extend archiveFilesOverlay;
+  fixGhc = ghcPackage0: lib.pipe ghcPackage0 [
+    # musl does not support libdw's alleged need for `dlopen()`, see:
+    #     https://github.com/nh2/static-haskell-nix/pull/116#issuecomment-1585786484
+    #
+    # Nixpkgs has the `enableDwarf` argument only for GHCs versions that are built
+    # with Hadrian (`common-hadrian.nix`), which in nixpkgs is the case for GHC >= 9.6.
+    # So set `enableDwarf = true`, but not for older versions known to not use Hadrian.
+    (ghcPackage:
+      if lib.any (prefix: lib.strings.hasPrefix prefix compiler) ["ghc8" "ghc90" "ghc92" "ghc94"]
+        then ghcPackage # GHC < 9.6, no Hadrian
+        else ghcPackage.override { enableDwarf = false; }
+    )
+    (ghcPackage:
+      ghcPackage.override {
+        enableRelocatedStaticLibs = useArchiveFilesForTemplateHaskell;
+        enableShared = !useArchiveFilesForTemplateHaskell;
+       }
+    )
+  ];
 
+  setupGhcOverlay = final: previous:
+    let
+      initialHaskellPackages =
+        if integer-simple
+          # Note we don't have to set the `-finteger-simple` flag for packages that GHC
+          # depends on (e.g. text), because nix + GHC already do this for us:
+          #   https://github.com/ghc/ghc/blob/ghc-8.4.3-release/ghc.mk#L620-L626
+          #   https://github.com/peterhoeg/nixpkgs/commit/50050f3cc9e006daa6800f15a29e258c6e6fa4b3#diff-2f6f8fd152c14d37ebd849aa6382257aR35
+          then previous.haskell.packages.integer-simple."${compiler}"
+          else previous.haskell.packages."${compiler}";
+    in
+      {
+        haskellPackages = initialHaskellPackages.override (old: {
+
+          # To override GHC, we need to override both `ghc` and the one in
+          # `buildHaskellPackages` because otherwise this code in `geneic-builder.nix`
+          # will make our package depend on 2 different GHCs:
+          #     nativeGhc = buildHaskellPackages.ghc;
+          #     depsBuildBuild = [ nativeGhc ] ...
+          #     nativeBuildInputs = [ ghc removeReferencesTo ] ...
+          #
+          ghc = fixGhc old.ghc;
+          buildHaskellPackages = old.buildHaskellPackages.override (oldBuildHaskellPackages: {
+            ghc = fixGhc oldBuildHaskellPackages.ghc;
+          });
+        });
+      };
+
+  pkgsWithGhc = pkgsWithArchiveFiles.extend setupGhcOverlay;
 
   # This overlay "fixes up" Haskell libraries so that static linking works.
   # See note "Don't add new packages here" below!
@@ -1596,7 +1594,7 @@ let
       };
 
 
-  pkgsWithHaskellLibsReadyForStaticLinking = pkgsWithArchiveFiles.extend haskellLibsReadyForStaticLinkingOverlay;
+  pkgsWithHaskellLibsReadyForStaticLinking = pkgsWithGhc.extend haskellLibsReadyForStaticLinkingOverlay;
 
   # Overlay all Haskell executables are statically linked.
   staticHaskellBinariesOverlay = final: previous: {

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -574,6 +574,56 @@ let
       makeFlags = [ "curl_LDFLAGS=-all-static" ];
     });
 
+  fixGhc = ghcPackage0: lib.pipe ghcPackage0 [
+    # musl does not support libdw's alleged need for `dlopen()`, see:
+    #     https://github.com/nh2/static-haskell-nix/pull/116#issuecomment-1585786484
+    #
+    # Nixpkgs has the `enableDwarf` argument only for GHCs versions that are built
+    # with Hadrian (`common-hadrian.nix`), which in nixpkgs is the case for GHC >= 9.6.
+    # So set `enableDwarf = true`, but not for older versions known to not use Hadrian.
+    (ghcPackage:
+      if lib.any (prefix: lib.strings.hasPrefix prefix compiler) ["ghc8" "ghc90" "ghc92" "ghc94"]
+        then ghcPackage # GHC < 9.6, no Hadrian
+        else ghcPackage.override { enableDwarf = false; }
+    )
+    (ghcPackage:
+      ghcPackage.override {
+        enableRelocatedStaticLibs = useArchiveFilesForTemplateHaskell;
+        enableShared = !useArchiveFilesForTemplateHaskell;
+       }
+    )
+  ];
+
+  setupGhcOverlay = final: previous:
+    let
+      initialHaskellPackages =
+        if integer-simple
+          # Note we don't have to set the `-finteger-simple` flag for packages that GHC
+          # depends on (e.g. text), because nix + GHC already do this for us:
+          #   https://github.com/ghc/ghc/blob/ghc-8.4.3-release/ghc.mk#L620-L626
+          #   https://github.com/peterhoeg/nixpkgs/commit/50050f3cc9e006daa6800f15a29e258c6e6fa4b3#diff-2f6f8fd152c14d37ebd849aa6382257aR35
+          then previous.haskell.packages.integer-simple."${compiler}"
+          else previous.haskell.packages."${compiler}";
+    in
+      {
+        haskellPackages = initialHaskellPackages.override (old: {
+
+          # To override GHC, we need to override both `ghc` and the one in
+          # `buildHaskellPackages` because otherwise this code in `geneic-builder.nix`
+          # will make our package depend on 2 different GHCs:
+          #     nativeGhc = buildHaskellPackages.ghc;
+          #     depsBuildBuild = [ nativeGhc ] ...
+          #     nativeBuildInputs = [ ghc removeReferencesTo ] ...
+          #
+          ghc = fixGhc old.ghc;
+          buildHaskellPackages = old.buildHaskellPackages.override (oldBuildHaskellPackages: {
+            ghc = fixGhc oldBuildHaskellPackages.ghc;
+          });
+        });
+      };
+
+  pkgsWithGhc = pkgs.extend setupGhcOverlay;
+
   # Overlay that enables `.a` files for as many system packages as possible.
   # This is in *addition* to `.so` files.
   # See also https://github.com/NixOS/nixpkgs/issues/61575
@@ -865,23 +915,12 @@ let
   };
 
 
-  pkgsWithArchiveFiles = pkgs.extend archiveFilesOverlay;
+  pkgsWithArchiveFiles = pkgsWithGhc.extend archiveFilesOverlay;
 
 
   # This overlay "fixes up" Haskell libraries so that static linking works.
   # See note "Don't add new packages here" below!
-  haskellLibsReadyForStaticLinkingOverlay = final: previous:
-    let
-      previousHaskellPackages =
-        if integer-simple
-          # Note we don't have to set the `-finteger-simple` flag for packages that GHC
-          # depends on (e.g. text), because nix + GHC already do this for us:
-          #   https://github.com/ghc/ghc/blob/ghc-8.4.3-release/ghc.mk#L620-L626
-          #   https://github.com/peterhoeg/nixpkgs/commit/50050f3cc9e006daa6800f15a29e258c6e6fa4b3#diff-2f6f8fd152c14d37ebd849aa6382257aR35
-          then previous.haskell.packages.integer-simple."${compiler}"
-          else previous.haskell.packages."${compiler}";
-    in
-      {
+  haskellLibsReadyForStaticLinkingOverlay = final: previous: {
         # Helper function to add pkg-config static lib flags to a Haskell derivation.
         # We put it directly into the `pkgs` package set so that following overlays
         # can use it as well if they want to.
@@ -922,7 +961,7 @@ let
           });
 
 
-        haskellPackages = previousHaskellPackages.override (old: {
+        haskellPackages = previous.haskellPackages.override (old: {
           overrides = final.lib.composeExtensions (old.overrides or (_: _: {})) (self: super:
             with final.haskell.lib;
             with final.staticHaskellHelpers;
@@ -1559,42 +1598,9 @@ let
 
   pkgsWithHaskellLibsReadyForStaticLinking = pkgsWithArchiveFiles.extend haskellLibsReadyForStaticLinkingOverlay;
 
-  fixGhc = ghcPackage0: lib.pipe ghcPackage0 [
-    # musl does not support libdw's alleged need for `dlopen()`, see:
-    #     https://github.com/nh2/static-haskell-nix/pull/116#issuecomment-1585786484
-    #
-    # Nixpkgs has the `enableDwarf` argument only for GHCs versions that are built
-    # with Hadrian (`common-hadrian.nix`), which in nixpkgs is the case for GHC >= 9.6.
-    # So set `enableDwarf = true`, but not for older versions known to not use Hadrian.
-    (ghcPackage:
-      if lib.any (prefix: lib.strings.hasPrefix prefix compiler) ["ghc8" "ghc90" "ghc92" "ghc94"]
-        then ghcPackage # GHC < 9.6, no Hadrian
-        else ghcPackage.override { enableDwarf = false; }
-    )
-    (ghcPackage:
-      ghcPackage.override {
-        enableRelocatedStaticLibs = useArchiveFilesForTemplateHaskell;
-        enableShared = !useArchiveFilesForTemplateHaskell;
-       }
-    )
-  ];
-
   # Overlay all Haskell executables are statically linked.
   staticHaskellBinariesOverlay = final: previous: {
     haskellPackages = previous.haskellPackages.override (old: {
-
-      # To override GHC, we need to override both `ghc` and the one in
-      # `buildHaskellPackages` because otherwise this code in `geneic-builder.nix`
-      # will make our package depend on 2 different GHCs:
-      #     nativeGhc = buildHaskellPackages.ghc;
-      #     depsBuildBuild = [ nativeGhc ] ...
-      #     nativeBuildInputs = [ ghc removeReferencesTo ] ...
-      #
-      ghc = fixGhc old.ghc;
-      buildHaskellPackages = old.buildHaskellPackages.override (oldBuildHaskellPackages: {
-        ghc = fixGhc oldBuildHaskellPackages.ghc;
-      });
-
       overrides = final.lib.composeExtensions (old.overrides or (_: _: {})) (self: super:
         let
             # We have to use `useFixedCabal` here, and cannot just rely on the
@@ -1740,6 +1746,7 @@ in
 
     inherit lib;
 
+    inherit pkgsWithGhc;
     inherit pkgsWithArchiveFiles;
     inherit pkgsWithStaticHaskellBinaries;
 


### PR DESCRIPTION
This moves the GHC configuration/fixing/selection to the start, ensuring that `pkgsWithArchiveFiles` contains the "final" version of `ghc`.
This is important as some users of the `survey` are only interested in a copy of GHC and static libraries (e.g. https://github.com/tweag/skyscope/pull/94/files#diff-8cce62c1be86c722f621f909a18b4a5df8eef70b6399b40194894ad9ce09f0abR20), so can depend on just a subset of the patches made.

As a sanity check, we get the same derivation before and after this change for:
```nix
nix-repl> pkgs = import ./survey/default.nix { compiler = "ghc962"; }
nix-repl> pkgs.haskellPackages.ghc                                    
«derivation /nix/store/11rnlr5qbk1pxwk4zjyb3xyz8wz2fyx6-ghc-musl-9.6.2.drv»
```