### PR TITLE
Fix callPackage still producing dynamic executables

### DIFF
--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1709,11 +1709,15 @@ let
                  ])
                ]);
         in
-          final.lib.mapAttrs
+          (final.lib.mapAttrs
             (name: value:
               if (isProperHaskellPackage value && isExecutable value) then statify value else value
             )
-            super
+            super) // {
+            callPackage = path: args:
+              let value = super.callPackage path args; in
+              if (isProperHaskellPackage value && isExecutable value) then statify value else value;
+          }
       );
     });
   };


### PR DESCRIPTION
This was due to `staticHaskellBinariesOverlay` overlay changing every _existing_ package to build statically, but not every _new_ package called with `callPackage`.

Here's an example building against my own [`glualint`](https://github.com/FPtje/GLuaFixer):

### Before

```
cd survey
nix repl --file default.nix --print-build-logs
nix-repl> :b (haskellPackages.extend (normalPkgs.callPackage /home/falco/Programs/glualint/nix/haskell-overlay.nix {})).callPackage /home/falco/Programs/glualint/default.nix {
}
This derivation produced the following outputs:
  out -> /nix/store/5qfjn4xkw1wwybywjq5qxr1dhsd16kw0-glualint-0.1.0.0
file /nix/store/5qfjn4xkw1wwybywjq5qxr1dhsd16kw0-glualint-0.1.0.0/bin/glualint
/nix/store/5qfjn4xkw1wwybywjq5qxr1dhsd16kw0-glualint-0.1.0.0/bin/glualint: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /nix/store/134sxj760d4nx8g85scj0h41bf8p7b7j-musl-1.2.3/lib/ld-musl-x86_64.so.1, stripped
```

### After

```
nix-repl> :b (haskellPackages.extend (normalPkgs.callPackage /home/falco/Programs/glualint/nix/haskell-overlay.nix {})).callPackage /home/falco/Programs/glualint/default.nix {}

This derivation produced the following outputs:
  out -> /nix/store/24dbxj94lisb3hmcwjs3vkk8w4xlhsar-glualint-0.1.0.0

file /nix/store/24dbxj94lisb3hmcwjs3vkk8w4xlhsar-glualint-0.1.0.0/bin/glualint
/nix/store/24dbxj94lisb3hmcwjs3vkk8w4xlhsar-glualint-0.1.0.0/bin/glualint: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```