### PR TITLE
Use the same GHC derivation in pkgs and haskellPackages

### DIFF
--- a/survey/default.nix
+++ b/survey/default.nix
@@ -928,6 +928,7 @@ let
           };
         };
         haskellPackages = initialHaskellPackages;
+        ghc = final.haskellPackages.ghc;
       };
 
   pkgsWithGhc = pkgsWithArchiveFiles.extend setupGhcOverlay;


### PR DESCRIPTION
We currently have different `ghc` derivations between `pkgs` and `pkgs.haskellPackages`:

```
$ nix eval --raw --file survey/default.nix --argstr compiler ghc982 'pkgs.haskellPackages.ghc.drvPath'
/nix/store/snvnzcqaalblggv7jh2y82b4rl93nyz3-ghc-musl-9.8.2.drv
$ nix eval --raw --file survey/default.nix --argstr compiler ghc982 'pkgs.ghc.drvPath'
/nix/store/i5ksii8lmjaygm3vxz1hylfp7djgyfr2-ghc-musl-9.8.2.drv
```

We can compare the two derivations:

``` bash
diff -u \
  <(nix derivation show \
      "$(nix eval --raw --file survey/default.nix --argstr compiler ghc982 'pkgs.ghc.drvPath')" \
      | jq -S .) \
  <(nix derivation show \
      "$(nix eval --raw --file survey/default.nix --argstr compiler ghc982 'pkgs.haskellPackages.ghc.drvPath')" \
      | jq -S .)
```

The only (significant) difference is:
```diff
-      "dontDisableStatic": "1",
```

I believe this is because `applyDontDisableStatic` only maps over the attrs of the package set it is directly given; it does not recurse into nested attrsets like `haskell.compiler` or `haskell.packages`.

This PR sets the `pkgs.ghc` to the derivation _without_ `"dontDisableStatic": "1"`, from `pkgs.haskellPackages`.

As `dontDisableStatic` isn't used by [ghc](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/ghc/common-hadrian.nix) anyway, there is no difference to the output.