### PR TITLE
Upgrade to nixos-25.11

### DIFF
--- a/survey/default.nix
+++ b/survey/default.nix
@@ -488,6 +488,8 @@ let
       gssSupport = false;
       zlib = zlib_both;
       brotliSupport = false; # When brotli is enabled, the `curl` package currently fails to link in `CCLD curl` with error `ld: ../lib/.libs/libcurl.so: undefined reference to `_kBrotliPrefixCodeRanges'`
+      pslSupport = false; # Static libpsl link test fails: configure's AC_CHECK_LIB does `-lpsl` without transitive deps (libunistring, libidn2) needed for static linking
+      http3Support = false; # Static nghttp3/ngtcp2 libs not available in our overlay
     })).overrideAttrs (old: {
       dontDisableStatic = true;
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -719,17 +719,43 @@ let
     # So somehow, the above `zlib_static` uses *this* `zlib`, even though
     # the above uses `previous.zlib.override` and thus shouldn't see this one.
 
-    # Disable failing tests for postgresql on musl that should have no impact
-    # on the libpq that we need (collate.icu.utf8 and foreign regression tests)
-    # This approach is copied from PostgREST, see https://github.com/PostgREST/postgrest/pull/2002/files#diff-72929db01d3c689277a1e7777b5df1dbbb20c5de41d1502ff8ac6b443a4e74c6R45
-    postgresql = (previous.postgresql_14.overrideAttrs (old: { doCheck = false; })).override {
-      # We need libpq, which does not need systemd,
-      # and systemd doesn't currently build with musl.
-      systemdSupport = false;
-      # Kerberos is problematic on static:
-      #     configure: error: could not find function 'gss_init_sec_context' required for GSSAPI
+    # We only need `libpq`, not the full `postgresql` server. nixpkgs split
+    # `libpq` out as a standalone package; using it directly avoids dragging
+    # in the server's many build inputs (systemd, kerberos, pam, llvm-for-JIT)
+    # and sidesteps the LLVM-bitcode-in-`.a`-archives issue that
+    # `postgresql_17`'s `-flto` build path produces (postgres always builds
+    # with the LLVM/clang stdenv to make `-flto` work; gold can't link bitcode).
+    #
+    # `postInstall = ""` clears libpq.nix's default `rm -rfv $dev/lib/*.a`
+    # (which runs in the non-`isStatic` branch under pkgsMusl).
+    # https://github.com/NixOS/nixpkgs/pull/519070 adds `dontDisableStatic`
+    # support to libpq.nix; once on a version of nixpkgs containing that
+    # commit, this should be removed.
+    libpq = (previous.libpq.override {
+      # Kerberos doesn't build on musl/static:
+      #     configure: error: could not find function 'gss_store_cred_into' required for GSSAPI
       gssSupport = false;
-    };
+      # Disable PG18's libcurl-backed OAuth client. We don't need it and
+      # avoiding the dlopen-loaded `libpq-oauth-*.so` keeps the closure
+      # smaller.
+      curlSupport = false;
+      # Build libpq's `libpq.so` against the un-overridden (shared) openssl
+      # from pkgsMusl, not the `openssl = previous.openssl.override { static = true; }`
+      # that this overlay defines above. With static-only openssl,
+      # libpq.so's link `-lssl -lcrypto` would pull OpenSSL's
+      # `ossl_init_register_atexit_ossl_` (and its `atexit` / `pthread_exit`
+      # calls) *statically* into `libpq.so`, where PG18's `libpq-refs-stamp`
+      # policy check (`src/interfaces/libpq/Makefile`) rejects them:
+      #     "libpq must not be calling any function which invokes exit".
+      # Linking shared openssl keeps those references inside libssl.so.
+      # The `libpq.a` output is unaffected: it contains only libpq's own
+      # objects, and downstream static Haskell binaries supply static
+      # `libssl.a`/`libcrypto.a` separately via the `extra-libraries`
+      # propagation set up on `postgresql-libpq-pkgconfig`.
+      openssl = previous.openssl;
+    }).overrideAttrs (_: {
+      postInstall = "";
+    });
 
     procps = previous.procps.override {
       # systemd doesn't currently build with musl.
@@ -1324,32 +1350,32 @@ let
               hasql-notifications =
                 addStaticLinkerFlagsWithPkgconfig
                   super.hasql-notifications
-                  [ final.openssl final.postgresql ]
+                  [ final.openssl final.libpq ]
                   "--libs libpq";
               hasql-queue =
                 addStaticLinkerFlagsWithPkgconfig
                   super.hasql-queue
-                  [ final.openssl final.postgresql ]
+                  [ final.openssl final.libpq ]
                   "--libs libpq";
               pg-harness-server =
                 addStaticLinkerFlagsWithPkgconfig
                   super.pg-harness-server
-                  [ final.openssl final.postgresql ]
+                  [ final.openssl final.libpq ]
                   "--libs libpq";
               postgrest =
                 addStaticLinkerFlagsWithPkgconfig
                   super.postgrest
-                  [ final.openssl final.postgresql ]
+                  [ final.openssl final.libpq ]
                   "--libs libpq";
               postgresql-orm =
                 addStaticLinkerFlagsWithPkgconfig
                   super.postgresql-orm
-                  [ final.openssl final.postgresql ]
+                  [ final.openssl final.libpq ]
                   "--libs libpq";
               postgresql-schema =
                 addStaticLinkerFlagsWithPkgconfig
                   super.postgresql-schema
-                  [ final.openssl final.postgresql ]
+                  [ final.openssl final.libpq ]
                   "--libs openssl libpq";
               postgresql-simple-migration =
                 addStaticLinkerFlagsWithPkgconfig
@@ -1359,7 +1385,7 @@ let
               squeal-postgresql =
                 addStaticLinkerFlagsWithPkgconfig
                   super.squeal-postgresql
-                  [ final.openssl final.postgresql ]
+                  [ final.openssl final.libpq ]
                   "--libs openssl libpq";
               tmp-postgres =
                 addStaticLinkerFlagsWithPkgconfig
@@ -1371,7 +1397,7 @@ let
               postgresql-migration =
                 addStaticLinkerFlagsWithPkgconfig
                   super.postgresql-migration
-                  [ final.openssl final.postgresql ]
+                  [ final.openssl final.libpq ]
                   "--libs libpq libcrypto";
 
               xml-to-json =

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -1456,7 +1456,8 @@ let
                     libpng
                     libtiff
                     zlib_both
-                    lzma
+                    # liblzma C library now lives at `xz` in nixpkgs.
+                    xz
                     libwebp
                   ])
                   "--libs nettle sdl2 SDL2_image xcursor libpng libjpeg libtiff-4 libwebp";

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -34,10 +34,6 @@
       ghc9122 = "Cabal_3_14_1_0";
     }."${compiler}"),
 
-  # Use `integer-simple` instead of `integer-gmp` to avoid linking in
-  # this LGPL dependency statically.
-  integer-simple ? false,
-
   # Enable for fast iteration.
   # Note that this doesn't always work. I've already found tons of bugs
   # in packages when `-O0` is used, like
@@ -155,9 +151,7 @@ let
           then normalPkgs
           else pkgs;
       haskellPackagesToUseForSetupExe =
-        if integer-simple
-          then pkgsToUseForSetupExe.haskell.packages.integer-simple."${compiler}"
-          else pkgsToUseForSetupExe.haskell.packages."${compiler}";
+        pkgsToUseForSetupExe.haskell.packages."${compiler}";
     in
       haskellPackagesToUseForSetupExe.override (old: {
         overrides = pkgs.lib.composeExtensions (old.overrides or (_: _: {})) (self: super: {
@@ -281,9 +275,7 @@ let
   stackageExecutables =
     let
       normalHaskellPackages =
-        if integer-simple
-          then pkgs.haskell.packages.integer-simple."${compiler}"
-          else pkgs.haskell.packages."${compiler}";
+        pkgs.haskell.packages."${compiler}";
 
       stackageExecutables =
         let
@@ -910,13 +902,7 @@ let
   setupGhcOverlay = final: previous:
     let
       initialHaskellPackages =
-        if integer-simple
-          # Note we don't have to set the `-finteger-simple` flag for packages that GHC
-          # depends on (e.g. text), because nix + GHC already do this for us:
-          #   https://github.com/ghc/ghc/blob/ghc-8.4.3-release/ghc.mk#L620-L626
-          #   https://github.com/peterhoeg/nixpkgs/commit/50050f3cc9e006daa6800f15a29e258c6e6fa4b3#diff-2f6f8fd152c14d37ebd849aa6382257aR35
-          then final.haskell.packages.integer-simple."${compiler}"
-          else final.haskell.packages."${compiler}";
+        final.haskell.packages."${compiler}";
     in
       {
         haskell = previous.haskell // {
@@ -984,23 +970,7 @@ let
                 callCabal2nix =
                   final.haskellPackages.callCabal2nix;
 
-                add_integer-simple_if_needed = haskellPkgs: haskellPkgs // (
-                  # If the `integer-simple` flag is given, and there isn't already
-                  # an `integer-simple` in the Haskell package set, add one as `null`.
-                  # This works around the problem that `stack2nix`-generated Haskell
-                  # package sets lack the `integer-simple` entries, even when everything
-                  # is compiled with integer-simple, which leads to
-                  #   Setup: Encountered missing dependencies:
-                  #   integer-simple
-                  # This PR fixes it in stack2nix:
-                  #   https://github.com/input-output-hk/stack2nix/pull/167
-                  # We still maintain the addition here so that users can use upstream
-                  # `stack2nix` without problems.
-                  if integer-simple && !(builtins.hasAttr "integer-simple" haskellPkgs) then {
-                    integer-simple = null;
-                  } else {});
-
-            in add_integer-simple_if_needed {
+            in {
 
               # This overrides settings for all Haskell packages.
               mkDerivation = attrs: super.mkDerivation (attrs // {
@@ -1153,15 +1123,7 @@ let
                     if disableOptimization
                       then appendBuildFlag drv "--ghc-option=-O"
                       else drv;
-                  # `blaze-textual` has a flag that needs to be given explicitly
-                  # if `integer-simple` is to be used.
-                  # TODO Put this into the `integer-simple` compiler set in nixpkgs? In:
-                  #          https://github.com/NixOS/nixpkgs/blob/ef89b398/pkgs/top-level/haskell-packages.nix#L184
-                  handleIntegerSimple = drv:
-                    if integer-simple
-                      then enableCabalFlag drv "integer-simple"
-                      else drv;
-                in handleIntegerSimple (handleDisableOptimisation super.blaze-textual);
+                in handleDisableOptimisation super.blaze-textual;
 
               # `weigh`'s test suite fails when `-O0` is used
               # because that package inherently relies on optimisation to be on.
@@ -1572,11 +1534,6 @@ let
                     "--ld-option=-Wl,--start-group --ld-option=-Wl,-lstdc++"
                   ]);
 
-              cryptonite =
-                if integer-simple
-                  then disableCabalFlag super.cryptonite "integer-gmp"
-                  else super.cryptonite;
-
               # The test-suite of this package loops forever on 100% CPU (at least on `-O0`).
               bench-show = dontCheck super.bench-show;
               # The test-suite of this package loops forever on 100% CPU (at least on `-O0`).
@@ -1584,17 +1541,6 @@ let
               loop = dontCheck super.loop;
               # The test-suite of this package loops forever on 100% CPU (at least on `-O0`).
               matrix = dontCheck super.matrix;
-              # The test-suite of this package loops forever on 100% CPU (at least on `-O0`).
-              # TODO Ask Bas about it
-              scientific =
-                if integer-simple
-                  then dontCheck super.scientific
-                  else super.scientific;
-              # The test-suite of this package loops forever on 100% CPU (at least on `-O0`).
-              x509-validation =
-                if integer-simple
-                  then dontCheck super.x509-validation
-                  else super.x509-validation;
 
               # Tests depend on util-linux which depends on systemd
               hakyll =
@@ -1699,14 +1645,14 @@ let
                   # TODO Figure out why this and the below libffi are necessary.
                   #      `working` and `workingStackageExecutables` don't seem to need that,
                   #      but `static-stack2nix-builder-example` does.
-                  (final.lib.optionals (!integer-simple) [
+                  [
                     "--extra-lib-dirs=${final.gmp6.override { withStatic = true; }}/lib"
-                  ])
-                  (final.lib.optionals (!integer-simple && approach == "pkgsMusl") [
+                  ]
+                  (final.lib.optionals (approach == "pkgsMusl") [
                     # GHC needs this if it itself wasn't already built against static libffi
                     # (which is the case in `pkgsStatic` only):
                     "--extra-lib-dirs=${final.libffi}/lib"
-                 ])
+                  ])
                ]);
         in
           final.lib.mapAttrs

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -19,7 +19,7 @@
   ])."${approach}",
 
   # When changing this, also change the default version of Cabal declared below
-  compiler ? "ghc965",
+  compiler ? "ghc984",
 
   # Tries to use `.a` files when evaluating TH, instead of `.so` files.
   useArchiveFilesForTemplateHaskell ? false,
@@ -27,12 +27,11 @@
   # See https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history
   defaultCabalPackageVersionComingWithGhc ?
     ({
-      ghc8107 = "Cabal_3_2_1_0";
-      ghc902 = "Cabal_3_4_1_0";
-      ghc928 = "Cabal_3_6_3_0";
       ghc948 = "Cabal_3_8_1_0";
-      ghc963 = "Cabal_3_10_1_0";
-      ghc965 = "Cabal_3_10_3_0";
+      ghc967 = "Cabal_3_10_3_0";
+      ghc984 = "Cabal_3_10_3_0";
+      ghc9103 = "Cabal_3_12_1_0";
+      ghc9122 = "Cabal_3_14_1_0";
     }."${compiler}"),
 
   # Use `integer-simple` instead of `integer-gmp` to avoid linking in

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -806,6 +806,15 @@ let
       postInstall = "";
     });
 
+    # nixpkgs's Haskell overlay drags the full `postgresql` server into the
+    # closure of `postgresql-simple` (as a test-tool dep, for spinning up a
+    # real DB during checks)
+    postgresql = previous.postgresql.override {
+      gssSupport = false;
+      curlSupport = false;
+      openssl = previous.openssl;
+    };
+
     procps = previous.procps.override {
       # systemd doesn't currently build with musl.
       withSystemd = false;
@@ -1394,60 +1403,38 @@ let
                   [ final.openssl final.zlib_both ]
                   "--libs openssl zlib";
 
-              # TODO For the below packages, it would be better if we could somehow make all users
-              # of postgresql-libpq link in openssl via pkgconfig.
-              hasql-notifications =
-                addStaticLinkerFlagsWithPkgconfig
-                  super.hasql-notifications
-                  [ final.openssl final.libpq ]
-                  "--libs libpq";
-              hasql-queue =
-                addStaticLinkerFlagsWithPkgconfig
-                  super.hasql-queue
-                  [ final.openssl final.libpq ]
-                  "--libs libpq";
-              pg-harness-server =
-                addStaticLinkerFlagsWithPkgconfig
-                  super.pg-harness-server
-                  [ final.openssl final.libpq ]
-                  "--libs libpq";
-              postgrest =
-                addStaticLinkerFlagsWithPkgconfig
-                  super.postgrest
-                  [ final.openssl final.libpq ]
-                  "--libs libpq";
-              postgresql-orm =
-                addStaticLinkerFlagsWithPkgconfig
-                  super.postgresql-orm
-                  [ final.openssl final.libpq ]
-                  "--libs libpq";
-              postgresql-schema =
-                addStaticLinkerFlagsWithPkgconfig
-                  super.postgresql-schema
-                  [ final.openssl final.libpq ]
-                  "--libs openssl libpq";
-              postgresql-simple-migration =
-                addStaticLinkerFlagsWithPkgconfig
-                  super.postgresql-simple-migration
-                  [ final.openssl ]
-                  "--libs openssl";
-              squeal-postgresql =
-                addStaticLinkerFlagsWithPkgconfig
-                  super.squeal-postgresql
-                  [ final.openssl final.libpq ]
-                  "--libs openssl libpq";
-              tmp-postgres =
-                addStaticLinkerFlagsWithPkgconfig
-                  (dontCheck super.tmp-postgres) # flaky/stuck tests: https://github.com/jfischoff/tmp-postgres/issues/273
-                  [ final.openssl ]
-                  "--libs openssl";
-
-              # This one needs `libcrypto` explicitly for reasons not yet investigated. `libpq` should pull it in via `openssl`.
-              postgresql-migration =
-                addStaticLinkerFlagsWithPkgconfig
-                  super.postgresql-migration
-                  [ final.openssl final.libpq ]
-                  "--libs libpq libcrypto";
+              # Route libpq's static-link deps through `postgresql-libpq-pkgconfig`
+              # so every Haskell `libpq` consumer picks them up under
+              # `--enable-executable-static`. nixpkgs's `configuration-nix.nix`
+              # wires the Haskell `postgresql-libpq` binding through this
+              # sub-package, so propagation is centralised here.
+              #
+              # Two pieces:
+              #   - `addPkgconfigDepend openssl`: makes `libssl.pc`/`libcrypto.pc`
+              #     available so `pkg-config --static --libs libpq` resolves
+              #     `libpq.pc`'s `Requires.private` -- otherwise `-lssl`/`-lcrypto`
+              #     are silently dropped from the link line.
+              #   - `prePatch` injects `extra-libraries: pq, pgcommon, pgport, ssl,
+              #     crypto` into the `.cabal`. GHC aggregates each dep's
+              #     `InstalledPackageInfo.extraLibraries` at link time, so every
+              #     transitive consumer picks them up.
+              #
+              # `pq` first: ld walks static archives left-to-right, so
+              # `libpgcommon.a`'s objects would be discarded before `libpq.a`
+              # introduces references to them.
+              postgresql-libpq-pkgconfig =
+                let
+                  withExtraLibs = overrideCabal super.postgresql-libpq-pkgconfig (drv: {
+                    # `printf` constructs the multi-line replacement so the cabal
+                    # indentation isn't eaten by Nix's `''...''` dedent.
+                    prePatch = (drv.prePatch or "") + ''
+                      substituteInPlace postgresql-libpq-pkgconfig.cabal --replace-fail \
+                        "pkgconfig-depends: libpq >=14.12" \
+                        "$(printf 'pkgconfig-depends: libpq >=14.12\n  extra-libraries: pq, pgcommon, pgport, ssl, crypto')"
+                    '';
+                  });
+                in
+                  final.haskell.lib.addPkgconfigDepend withExtraLibs final.openssl;
 
               xml-to-json =
                 addStaticLinkerFlagsWithPkgconfig
@@ -1764,7 +1751,7 @@ in
         bench
         dhall
         dhall-json
-        # postgrest # Dependency `configurator-pg-0.2.7` does not build due to `megaparsec >=7.0.0 && <9.3` (This is fixed in `configurator-pg- 0.2.8`)
+        postgrest
         # proto3-suite # Dependency `proto3-wire-1.4.0` does not build due to `bytestring >=0.10.6.0 && <0.11.0`
         hsyslog # Small example of handling https://github.com/NixOS/nixpkgs/issues/43849 correctly
         # aura # `aur` maked as broken in nixpkgs, but works here with `allowBroken = true;` actually

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -580,6 +580,55 @@ let
         enableShared = !useArchiveFilesForTemplateHaskell;
        }
     )
+
+    # GHC bug workaround: when GHC is built with `-split-sections`, both the
+    # make-based and hadrian build systems invoke `ld -r` with the linker
+    # script `driver/utils/merge_sections.ld` (in GHC's source tree since at
+    # least 9.0) to produce a per-package merged `HS<pkg>-<ver>-<hash>.o`
+    # ("ghci library") object that GHC's RTS linker loads at TH-eval time.
+    # That linker script catches `.rodata.cst32` under the `.rodata`
+    # wildcard, which loses the 32-byte alignment of AVX2 SIMD constants
+    # emitted by gcc into that section. The merged `.o` is therefore
+    # defective: any code that does an aligned 256-bit load against one of
+    # those constants (e.g. bytestring's `isValidUtf8` AVX2 path on inputs
+    # ≥ 128 bytes) faults at TH-eval time when the RTS linker happens to
+    # map `.rodata` at a non-32-aligned address. Whether the fault actually
+    # fires depends on load-time placement: in some configurations the
+    # constants coincidentally land on a 32-byte boundary and the defect
+    # stays latent.
+    #
+    # We make two changes — either on its own should be enough to prevent
+    # the crash:
+    #  1. `postPatch` patches `merge_sections.ld` to preserve
+    #     `.rodata.cst32` (and `.cst64`) as their own output sections.
+    #     This is a fix for the underlying bug, included to describe the
+    #     cause. It is guarded on file existence so a future GHC that
+    #     drops `merge_sections.ld` is unaffected.
+    #  2. `postFixup` deletes the merged `HS<pkg>-<ver>-<hash>.o` files
+    #     after install. The RTS linker then loads the `.a` archive
+    #     members instead, where the alignment is preserved per-object.
+    #     This is what removes the problem from the toolchain we ship.
+    #
+    # The second change has the same effect as upstream GHC commit
+    #     https://gitlab.haskell.org/ghc/ghc/-/commit/53038ea9
+    # which (post-9.12) removes the ghci-library merge step entirely:
+    # in both cases no merged `.o` is loaded, so the RTS linker uses
+    # the `.a` archive members. Drop this `lib.pipe` step once the
+    # toolchain moves to a GHC that includes that commit (≥ 9.14).
+    (ghcPackage:
+      ghcPackage.overrideAttrs (old: {
+        postPatch = (old.postPatch or "") + ''
+          if [ -f driver/utils/merge_sections.ld ]; then
+            substituteInPlace driver/utils/merge_sections.ld --replace \
+              '.rodata.cst16 : {' \
+              '.rodata.cst64 : { *(.rodata.cst64*) } .rodata.cst32 : { *(.rodata.cst32*) } .rodata.cst16 : {'
+          fi
+        '';
+        postFixup = (old.postFixup or "") + ''
+          find "$out" \( -name 'HS*-*.o' -o -name 'HS*-*.p_o' \) -delete
+        '';
+      })
+    )
   ];
 
 

--- a/survey/default.nix
+++ b/survey/default.nix
@@ -561,6 +561,32 @@ let
       makeFlags = [ "curl_LDFLAGS=-all-static" ];
     });
 
+  # Takes an openssl derivation and overrides it to have both `.a` and `.so`
+  # files. Openssl's shared build removes the `.a` files in postInstall, so
+  # we copy them in from a separately-built static-only variant.
+  statify_openssl = openssl_drv:
+    let
+      static = openssl_drv.override { static = true; };
+    in
+      openssl_drv.overrideAttrs (old: {
+        postInstall = (old.postInstall or "") + ''
+          cp ${static.out}/lib/*.a "$out/lib/"
+        '';
+      });
+
+  # Takes an ncurses derivation and overrides it to have both `.a` and `.so`
+  # files. Ncurses's shared build removes the `.a` files in postInstall, so
+  # we copy them in from a separately-built static-only variant.
+  statify_ncurses = ncurses_drv:
+    let
+      static = ncurses_drv.override { enableStatic = true; };
+    in
+      ncurses_drv.overrideAttrs (old: {
+        postInstall = (old.postInstall or "") + ''
+          cp ${static}/lib/*.a "$out/lib/"
+        '';
+      });
+
 
   fixGhc = ghcPackage0: lib.pipe ghcPackage0 [
     # musl does not support libdw's alleged need for `dlopen()`, see:
@@ -788,20 +814,6 @@ let
       # avoiding the dlopen-loaded `libpq-oauth-*.so` keeps the closure
       # smaller.
       curlSupport = false;
-      # Build libpq's `libpq.so` against the un-overridden (shared) openssl
-      # from pkgsMusl, not the `openssl = previous.openssl.override { static = true; }`
-      # that this overlay defines above. With static-only openssl,
-      # libpq.so's link `-lssl -lcrypto` would pull OpenSSL's
-      # `ossl_init_register_atexit_ossl_` (and its `atexit` / `pthread_exit`
-      # calls) *statically* into `libpq.so`, where PG18's `libpq-refs-stamp`
-      # policy check (`src/interfaces/libpq/Makefile`) rejects them:
-      #     "libpq must not be calling any function which invokes exit".
-      # Linking shared openssl keeps those references inside libssl.so.
-      # The `libpq.a` output is unaffected: it contains only libpq's own
-      # objects, and downstream static Haskell binaries supply static
-      # `libssl.a`/`libcrypto.a` separately via the `extra-libraries`
-      # propagation set up on `postgresql-libpq-pkgconfig`.
-      openssl = previous.openssl;
     }).overrideAttrs (_: {
       postInstall = "";
     });
@@ -812,7 +824,6 @@ let
     postgresql = previous.postgresql.override {
       gssSupport = false;
       curlSupport = false;
-      openssl = previous.openssl;
     };
 
     procps = previous.procps.override {
@@ -842,7 +853,14 @@ let
 
     libusb1 = previous.libusb1.override { withStatic = true; enableUdev = false; };
 
-    openssl = previous.openssl.override { static = true; };
+    ncurses = statify_ncurses previous.ncurses;
+
+    # `openssl` has to be passed `pkgsDontDisableStatic.openssl` rather
+    # than `previous.openssl`, because the helper's inner `.override`'s
+    # dependency walk through `previous` reaches `curl -> openssl` and
+    # ultimately resolves back to `final.openssl` (the dual-form override
+    # under construction), producing an infinite recursion.
+    openssl = statify_openssl pkgsDontDisableStatic.openssl;
 
     zstd = previous.zstd.override { enableStatic = true; };
 


### PR DESCRIPTION
Bring static-haskell-nix up to nixos-25.11, with GHC 9.8.4 as the new default compiler. The submodule bump itself is one small commit, but several adaptations were necessary along the way to keep `survey -A working` building, plus several genuinely substantive fixes for problems that only surface against the 25.11 toolchain.

The mechanical changes:

- Bump the `nixpkgs` submodule to the `nixos-25.11` tip.
- Move the default compiler from `ghc965` to `ghc984`, and refresh the `defaultCabalPackageVersionComingWithGhc` map. Each entry was verified against the actual `Cabal-*` directory in the installed GHC.
- Remove `integer-simple` support entirely. Modern GHCs no longer ship the `integer-simple` library, leaving the conditional unreachable.
- Disable `pslSupport` and `http3Support` on curl. `libpsl`'s `AC_CHECK_LIB` doesn't pass transitive `libunistring`/`libidn2` on the static link line, and `nghttp3`/`ngtcp2` don't ship a static archive in our overlay.
- Follow nixpkgs's rename of `lzma` to `xz`.

The substantive fixes:

- Switch the postgres-libpq C dependency from the full `postgresql_17` server to the standalone `libpq` derivation that nixpkgs split out in 25.11. The smaller closure dodges the `systemd`/`kerberos`/`pam`/`llvm-for-JIT` build inputs, and also dodges the LLVM-bitcode-in-`.a`-archives that `postgresql_17`'s `-flto` build path emits (gold can't link bitcode).

- Work around a GHC bug where the per-package merged `HS<pkg>-<ver>-<hash>.o` "ghci library" objects lose the 32-byte alignment of AVX2 SIMD constants in `.rodata.cst32`. The cause is `driver/utils/merge_sections.ld`'s `.rodata` wildcard catching them. The symptom is that GHC's RTS linker maps the defective object at TemplateHaskell-evaluation time, and `vmovdqa` faults on the misaligned constant. The workaround patches the linker script to preserve `.rodata.cst32` (and `.cst64`) as their own output sections, and also deletes the merged `.o` files after install so the RTS linker uses the per-archive members instead. Either change alone is enough, kept together as defence in depth. Upstream commit https://gitlab.haskell.org/ghc/ghc/-/commit/53038ea9 (post-9.12) removes the merge step entirely. Once on a GHC that contains that commit, this workaround should be dropped. A self-contained reproducer is attached as a comment below.

- Centralise the libpq / openssl static-link wiring inside `postgresql-libpq-pkgconfig`, the Haskell wrapper sub-package that nixpkgs's `configuration-nix.nix` routes every `postgresql-libpq` consumer through. Two pieces work together: an `addPkgconfigDepend openssl` so `pkg-config --static --libs libpq` can resolve `libpq.pc`'s `Requires.private`, and a `prePatch` that injects `extra-libraries: pq, pgcommon, pgport, ssl, crypto` into the `.cabal` so GHC's package-walking aggregation propagates the deps to every transitive consumer's link. `pq` first, because ld walks static archives left-to-right. This replaces the `addStaticLinkerFlagsWithPkgconfig` wrappers that the survey previously applied to each libpq consumer. The same change adds a `postgresql` override (`gssSupport`/`curlSupport` off) for packages whose closures pull in the full `postgresql_17` for tests (e.g. via `postgresql-simple`'s `addTestToolDepends`), and adds `postgrest`, `hasql-notifications`, `squeal-postgresql` to the `working` set's `pkgsMusl` section.

- Build `openssl` and `ncurses` in _both_ shared and static form via new `statify_openssl` / `statify_ncurses` helpers, matching the existing `statify_zlib` / `statify_curl_including_exe` convention.

Verified:

- `nix-build survey -A working` instantiates and builds.

- The resulting `postgrest` binary is fully statically linked:

    ```
    $ out=$(nix-build survey -A working.postgrest.bin --no-out-link)
    $ file "$out/bin/postgrest"
    ... ELF 64-bit LSB executable, x86-64, ..., statically linked, stripped
    $ ldd  "$out/bin/postgrest"
            not a dynamic executable
    ```

    Smoke-tested against a docker `postgres:17` instance with a minimal anon-role schema, serving GET requests over HTTP and returning the expected JSON.

Happy to take feedback on any of this.
